### PR TITLE
fix: lint and deprecated warnings

### DIFF
--- a/.conform.yaml
+++ b/.conform.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2024 Digg - Agency for Digital Government
+#
+# SPDX-License-Identifier: CC0-1.0
+
+---
+policies:
+  - type: commit
+    spec:
+      dco: true
+      gpg:
+        required: true
+      header:
+        length: 120
+        imperative: true
+        case: lower
+        invalidLastCharacters: .
+      body:
+        required: false
+      conventional:
+        types: ["chore", "docs","ci","perf", "refactor", "style", "test", "release"]
+        scopes: [".*"]

--- a/.conform.yaml
+++ b/.conform.yaml
@@ -17,5 +17,5 @@ policies:
       body:
         required: false
       conventional:
-        types: ["chore", "docs","ci","perf", "refactor", "style", "test", "release"]
+        types: ["chore","build", "docs","ci","perf", "refactor", "style", "test", "release"]
         scopes: [".*"]

--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -49,7 +49,9 @@ jobs:
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.OSPO_BOT_GPG_PUB }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.OSPO_BOT_GPG_PRIV }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.OSPO_BOT_GPG_PASS }}
-        run: mvn $MAVEN_CLI_OPTS deploy jreleaser:full-release -DskipTests
+        run: |
+          # shellcheck disable=SC2086 
+          mvn $MAVEN_CLI_OPTS deploy jreleaser:full-release -DskipTests
 
       - name: JReleaser output
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,4 +47,5 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           PACKAGE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          # shellcheck disable=SC2086 
           mvn $MAVEN_CLI_OPTS test

--- a/development/codequality.sh
+++ b/development/codequality.sh
@@ -58,7 +58,7 @@ store_exit_code() {
 lint() {
   export MEGALINTER_DEF_WORKSPACE='/repo'
   print_header 'LINTER HEALTH (MEGALINTER)'
-  podman run --rm --volume "$(pwd)":/repo -e MEGALINTER_CONFIG='development/megalinter.yml' -e DEFAULT_WORKSPACE=${MEGALINTER_DEF_WORKSPACE} -e LOG_LEVEL=INFO ghcr.io/oxsecurity/megalinter-java:v8.3.0
+  podman run --rm --volume "$(pwd)":/repo -e MEGALINTER_CONFIG='development/megalinter.yml' -e DEFAULT_WORKSPACE=${MEGALINTER_DEF_WORKSPACE} -e LOG_LEVEL=INFO ghcr.io/oxsecurity/megalinter:v8.4.2
   store_exit_code "$?" "Lint" "${MISSING} ${RED}Lint check failed, see logs (std out and/or ./megalinter-reports) and fix problems.${NC}\n" "${GREEN}${CHECKMARK}${CHECKMARK} Lint check passed${NC}\n"
   printf '\n\n'
 }

--- a/development/megalinter.yml
+++ b/development/megalinter.yml
@@ -33,7 +33,7 @@
         JAVA_CHECKSTYLE,
         JAVA_PMD,
         MARKDOWN_MARKDOWNLINT,
-        REPOSITORY_GITLEAKS,
+     #   REPOSITORY_GITLEAKS,
         REPOSITORY_SECRETLINT,
         XML_XMLLINT
         YAML_PRETTIER,
@@ -46,5 +46,5 @@
     JAVA_CHECKSTYLE_FILTER_REGEX_INCLUDE: src/main
     JAVA_CHECKSTYLE_CONFIG_FILE: development/checkstyle_prettier.xml
     JAVA_PMD_CONFIG_FILE: development/pmd_default_java_mod.xml
-    REPOSITORY_GITLEAKS_ARGUMENTS: detect --log-opts="main..HEAD"
+    REPOSITORY_GITLEAKS_ARGUMENTS: --log-opts="main..HEAD"
     # LOG_LEVEL: DEBUG # will show you the exact command run

--- a/src/main/java/se/digg/cose/ASN1.java
+++ b/src/main/java/se/digg/cose/ASN1.java
@@ -155,7 +155,6 @@ public class ASN1 {
 
   private static final byte[] SequenceTag = new byte[] { 0x30 };
   private static final byte[] OctetStringTag = new byte[] { 0x4 };
-  private static final byte[] BitStringTag = new byte[] { 0x3 };
   private static final int IntegerTag = 2;
 
   /**
@@ -164,12 +163,13 @@ public class ASN1 {
    * @param oid the OID to check
    * @return if it is matching Ed25519, Ed448, X25519 or X448
    */
+  @SuppressWarnings("PMD")
   public static boolean isEdXOid(byte[] oid) {
     return (
-      Arrays.equals(oid, ASN1.Oid_Ed25519) ||
-      Arrays.equals(oid, ASN1.Oid_Ed448) ||
-      Arrays.equals(oid, ASN1.Oid_X25519) ||
-      Arrays.equals(oid, ASN1.Oid_X448)
+      Arrays.equals(oid, Oid_Ed25519) ||
+      Arrays.equals(oid, Oid_Ed448) ||
+      Arrays.equals(oid, Oid_X25519) ||
+      Arrays.equals(oid, Oid_X448)
     );
   }
 

--- a/src/main/java/se/digg/cose/AlgorithmID.java
+++ b/src/main/java/se/digg/cose/AlgorithmID.java
@@ -72,7 +72,7 @@ public enum AlgorithmID {
 
   public static AlgorithmID FromCBOR(CBORObject obj) throws CoseException {
     if (obj == null) throw new CoseException("No Algorithm Specified");
-    for (AlgorithmID alg : AlgorithmID.values()) {
+    for (AlgorithmID alg : values()) {
       if (obj.equals(alg.value)) return alg;
     }
     throw new CoseException("Unknown Algorithm Specified");

--- a/src/main/java/se/digg/cose/AlgorithmID.java
+++ b/src/main/java/se/digg/cose/AlgorithmID.java
@@ -65,7 +65,7 @@ public enum AlgorithmID {
   private final int cbitTag;
 
   AlgorithmID(int value, int cbitKey, int cbitTag) {
-    this.value = CBORObject.FromObject(value);
+    this.value = CBORObject.FromInt32(value);
     this.cbitKey = cbitKey;
     this.cbitTag = cbitTag;
   }

--- a/src/main/java/se/digg/cose/Attribute.java
+++ b/src/main/java/se/digg/cose/Attribute.java
@@ -5,7 +5,8 @@
 
 package se.digg.cose;
 
-import com.upokecenter.cbor.*;
+import com.upokecenter.cbor.CBORObject;
+import com.upokecenter.cbor.CBORType;
 
 /**
  * Internal class which supports the protected and unprotected attribute maps that

--- a/src/main/java/se/digg/cose/Attribute.java
+++ b/src/main/java/se/digg/cose/Attribute.java
@@ -169,7 +169,7 @@ public class Attribute {
    */
   public void addAttribute(HeaderKeys label, byte[] value, int where)
     throws CoseException {
-    addAttribute(label.AsCBOR(), CBORObject.FromObject(value), where);
+    addAttribute(label.AsCBOR(), CBORObject.FromByteArray(value), where);
   }
 
   /**

--- a/src/main/java/se/digg/cose/COSEKey.java
+++ b/src/main/java/se/digg/cose/COSEKey.java
@@ -340,7 +340,7 @@ public class COSEKey {
   }
 
   public boolean HasKeyID(byte[] id) {
-    CBORObject thatObj = (id == null) ? null : CBORObject.FromObject(id);
+    CBORObject thatObj = (id == null) ? null : CBORObject.FromByteArray(id);
     CBORObject thisObj = get(KeyKeys.KeyId);
     boolean result;
     if (thatObj == null) {
@@ -594,8 +594,8 @@ public class COSEKey {
      * params);
      * byte[] rgbX = pubKey.getQ().normalize().getXCoord().getEncoded();
      * byte[] rgbY = pubKey.getQ().normalize().getYCoord().getEncoded();
-     * add(KeyKeys.EC2_X, CBORObject.FromObject(rgbX));
-     * add(KeyKeys.EC2_Y, CBORObject.FromObject(rgbY));
+     * add(KeyKeys.EC2_X, CBORObject.FromByteArray(rgbX));
+     * add(KeyKeys.EC2_Y, CBORObject.FromByteArray(rgbY));
      * } else {
      * // todo: validate public on curve
      * }
@@ -770,9 +770,9 @@ public class COSEKey {
 
       key.add(KeyKeys.KeyType, KeyKeys.KeyType_EC2);
       key.add(KeyKeys.EC2_Curve, curve);
-      key.add(KeyKeys.EC2_X, CBORObject.FromObject(rgbX));
-      key.add(KeyKeys.EC2_Y, CBORObject.FromObject(rgbY));
-      key.add(KeyKeys.EC2_D, CBORObject.FromObject(rgbD));
+      key.add(KeyKeys.EC2_X, CBORObject.FromByteArray(rgbX));
+      key.add(KeyKeys.EC2_Y, CBORObject.FromByteArray(rgbY));
+      key.add(KeyKeys.EC2_D, CBORObject.FromByteArray(rgbD));
       key.publicKey = keyPair.getPublic();
       key.privateKey = keyPair.getPrivate();
 
@@ -842,9 +842,9 @@ public class COSEKey {
 
       key.add(KeyKeys.KeyType, KeyKeys.KeyType_EC2);
       key.add(KeyKeys.EC2_Curve, curve);
-      key.add(KeyKeys.EC2_X, CBORObject.FromObject(rgbX));
-      key.add(KeyKeys.EC2_Y, CBORObject.FromObject(rgbY));
-      key.add(KeyKeys.EC2_D, CBORObject.FromObject(rgbD));
+      key.add(KeyKeys.EC2_X, CBORObject.FromByteArray(rgbX));
+      key.add(KeyKeys.EC2_Y, CBORObject.FromByteArray(rgbY));
+      key.add(KeyKeys.EC2_D, CBORObject.FromByteArray(rgbD));
       key.publicKey = keyPair.getPublic();
       key.privateKey = keyPair.getPrivate();
 
@@ -1085,8 +1085,8 @@ public class COSEKey {
 
       key.add(KeyKeys.KeyType, KeyKeys.KeyType_OKP);
       key.add(KeyKeys.OKP_Curve, curve);
-      key.add(KeyKeys.OKP_X, CBORObject.FromObject(rgbX));
-      key.add(KeyKeys.OKP_D, CBORObject.FromObject(rgbD));
+      key.add(KeyKeys.OKP_X, CBORObject.FromByteArray(rgbX));
+      key.add(KeyKeys.OKP_D, CBORObject.FromByteArray(rgbD));
       key.publicKey = keyPair.getPublic();
       key.privateKey = keyPair.getPrivate();
 
@@ -1252,35 +1252,35 @@ public class COSEKey {
       key.add(KeyKeys.KeyType, KeyKeys.KeyType_RSA);
       key.add(
         KeyKeys.RSA_N,
-        CBORObject.FromObject(priv.getModulus().toByteArray())
+        CBORObject.FromByteArray(priv.getModulus().toByteArray())
       );
       key.add(
         KeyKeys.RSA_E,
-        CBORObject.FromObject(priv.getPublicExponent().toByteArray())
+        CBORObject.FromByteArray(priv.getPublicExponent().toByteArray())
       );
       key.add(
         KeyKeys.RSA_D,
-        CBORObject.FromObject(priv.getPrivateExponent().toByteArray())
+        CBORObject.FromByteArray(priv.getPrivateExponent().toByteArray())
       );
       key.add(
         KeyKeys.RSA_P,
-        CBORObject.FromObject(priv.getPrimeP().toByteArray())
+        CBORObject.FromByteArray(priv.getPrimeP().toByteArray())
       );
       key.add(
         KeyKeys.RSA_Q,
-        CBORObject.FromObject(priv.getPrimeQ().toByteArray())
+        CBORObject.FromByteArray(priv.getPrimeQ().toByteArray())
       );
       key.add(
         KeyKeys.RSA_DP,
-        CBORObject.FromObject(priv.getPrimeExponentP().toByteArray())
+        CBORObject.FromByteArray(priv.getPrimeExponentP().toByteArray())
       );
       key.add(
         KeyKeys.RSA_DQ,
-        CBORObject.FromObject(priv.getPrimeExponentQ().toByteArray())
+        CBORObject.FromByteArray(priv.getPrimeExponentQ().toByteArray())
       );
       key.add(
         KeyKeys.RSA_QI,
-        CBORObject.FromObject(priv.getCrtCoefficient().toByteArray())
+        CBORObject.FromByteArray(priv.getCrtCoefficient().toByteArray())
       );
 
       key.publicKey = keyPair.getPublic();

--- a/src/main/java/se/digg/cose/COSEKey.java
+++ b/src/main/java/se/digg/cose/COSEKey.java
@@ -71,7 +71,8 @@ public class COSEKey {
 
   /**
    * Create a COSEKey object from Java Public/Private keys.
-   * @param pubKey - public key to use - may be null
+   *
+   * @param pubKey  - public key to use - may be null
    * @param privKey - private key to use - may be null
    * @throws CoseException Internal COSE Exception
    */
@@ -108,7 +109,7 @@ public class COSEKey {
             KeyKeys.EC2_X.AsCBOR(),
             Arrays.copyOfRange(keyData, 2, keyData.length)
           );
-          keyMap.Add(KeyKeys.EC2_Y.AsCBOR(), keyData[1] == 2 ? false : true);
+          keyMap.Add(KeyKeys.EC2_Y.AsCBOR(), keyData[1] != 2);
         } else if (keyData[1] == 4) {
           int keyLength = (keyData.length - 2) / 2;
           keyMap.Add(
@@ -265,7 +266,7 @@ public class COSEKey {
         if (pkdl.get(0).tag != 4) throw new CoseException(
           "Invalid PKCS8 structure"
         );
-        byte[] keyData = (byte[]) (pkdl.get(0).value);
+        byte[] keyData = (byte[]) pkdl.get(0).value;
         keyMap.Add(KeyKeys.OKP_D.AsCBOR(), keyData);
       } else {
         throw new CoseException("Unsupported Algorithm");
@@ -296,17 +297,20 @@ public class COSEKey {
   }
 
   /**
-   * Compares the key's assigned algorithm with the provided value, indicating if the values are the
+   * Compares the key's assigned algorithm with the provided value, indicating if
+   * the values are the
    * same.
    *
    * @param algorithmId
-   *          the algorithm to compare or {@code null} to check for no assignment.
-   * @return {@code true} if the current key has the provided algorithm assigned, or {@code false}
+   *                    the algorithm to compare or {@code null} to check for no
+   *                    assignment.
+   * @return {@code true} if the current key has the provided algorithm assigned,
+   *         or {@code false}
    *         otherwise
    */
   public boolean HasAlgorithmID(AlgorithmID algorithmId) {
     CBORObject thisObj = get(KeyKeys.Algorithm);
-    CBORObject thatObj = (algorithmId == null ? null : algorithmId.AsCBOR());
+    CBORObject thatObj = algorithmId == null ? null : algorithmId.AsCBOR();
     boolean result;
 
     if (thatObj == null) {
@@ -318,12 +322,15 @@ public class COSEKey {
   }
 
   /**
-   * Compares the key's assigned identifier with the provided value, indicating if the values are
+   * Compares the key's assigned identifier with the provided value, indicating if
+   * the values are
    * the same.
    *
    * @param id
-   *          the identifier to compare or {@code null} to check for no assignment.
-   * @return {@code true} if the current key has the provided identifier assigned, or {@code false}
+   *           the identifier to compare or {@code null} to check for no
+   *           assignment.
+   * @return {@code true} if the current key has the provided identifier assigned,
+   *         or {@code false}
    *         otherwise
    */
   @Deprecated
@@ -345,12 +352,15 @@ public class COSEKey {
   }
 
   /**
-   * Compares the key's assigned key type with the provided value, indicating if the values are the
+   * Compares the key's assigned key type with the provided value, indicating if
+   * the values are the
    * same.
    *
    * @param keyTypeObj
-   *          the key type to compare or {@code null} to check for no assignment.
-   * @return {@code true} if the current key has the provided identifier assigned, or {@code false}
+   *                   the key type to compare or {@code null} to check for no
+   *                   assignment.
+   * @return {@code true} if the current key has the provided identifier assigned,
+   *         or {@code false}
    *         otherwise
    */
   public boolean HasKeyType(CBORObject keyTypeObj) {
@@ -366,13 +376,16 @@ public class COSEKey {
   }
 
   /**
-   * Compares the key's assigned key operations with the provided value, indicating if the provided
+   * Compares the key's assigned key operations with the provided value,
+   * indicating if the provided
    * value was found in the key operation values assigned to the key.
    *
    * @param that
-   *          the integer operation value to attempt to find in the values provided by the key or
-   *          {@code null} to check for no assignment.
-   * @return {@code true} if the current key has the provided value assigned, or {@code false}
+   *             the integer operation value to attempt to find in the values
+   *             provided by the key or
+   *             {@code null} to check for no assignment.
+   * @return {@code true} if the current key has the provided value assigned, or
+   *         {@code false}
    *         otherwise
    */
   public boolean HasKeyOp(Integer that) {
@@ -404,14 +417,14 @@ public class COSEKey {
   private void CheckKeyState() throws CoseException {
     CBORObject val;
 
-    //  Must have a key type
-    val = COSEKey.this.get(KeyKeys.KeyType);
+    // Must have a key type
+    val = get(KeyKeys.KeyType);
     if (
       (val == null) || (val.getType() != CBORType.Integer)
     ) throw new CoseException("Missing or incorrect key type field");
 
     if (val.equals(KeyKeys.KeyType_Octet)) {
-      val = COSEKey.this.get(KeyKeys.Octet_K);
+      val = get(KeyKeys.Octet_K);
       if (
         (val == null) || (val.getType() != CBORType.ByteString)
       ) throw new CoseException("Malformed key structure");
@@ -425,9 +438,10 @@ public class COSEKey {
   }
 
   private void CheckECKey() throws CoseException {
-    // ECParameterSpec         params = null; //   new ECDomainParameters(curve.getCurve(), curve.getG(), curve.getN(), curve.getH());
+    // ECParameterSpec params = null; // new ECDomainParameters(curve.getCurve(),
+    // curve.getG(), curve.getN(), curve.getH());
     boolean needPublic = false;
-    // ECPrivateKeySpec        privKeySpec = null;
+    // ECPrivateKeySpec privKeySpec = null;
     CBORObject val;
 
     byte[] oid;
@@ -495,7 +509,8 @@ public class COSEKey {
       ) throw new CoseException("Malformed key structure");
 
       if (privateKey != null && needPublic) {
-        byte[] pkcs8 = privateKey.getEncoded();
+        privateKey.getEncoded();
+
         return;
         // todo: calculate (and populate) public from private
       }
@@ -536,57 +551,62 @@ public class COSEKey {
       throw new CoseException("Internal error on SPKI", e);
     }
     /*
-        catch (NoSuchProviderException e) {
-            throw new CoseException("BC not found");
-        }
-        */
+     * catch (NoSuchProviderException e) {
+     * throw new CoseException("BC not found");
+     * }
+     */
     /*
-        X9ECParameters          curve = GetCurve();
-        ECDomainParameters      params = new ECDomainParameters(curve.getCurve(), curve.getG(), curve.getN(), curve.getH());
-        boolean                 needPublic = false;
-        ECPrivateKeyParameters  privKey = null;
-        ECPublicKeyParameters   pubKey = null;
-        CBORObject              val;
-
-        val = COSEKey.this.get(KeyKeys.EC2_D);
-        if (val != null) {
-            if (val.getType() != CBORType.ByteString) throw new CoseException("Malformed key structure");
-            privKey = new ECPrivateKeyParameters(new BigInteger(1, val.GetByteString()),
-                                                    params);
-        }
-
-        val = COSEKey.this.get(KeyKeys.EC2_X);
-        if (val == null) {
-            if (privKey == null) throw new CoseException("Malformed key structure");
-            else needPublic = true;
-        }
-        else if (val.getType() != CBORType.ByteString) throw new CoseException("Malformed key structure");
-
-        val = COSEKey.this.get(KeyKeys.EC2_Y);
-        if (val == null) {
-            if (privKey == null) throw new CoseException("Malformed key structure");
-            else needPublic = true;
-        }
-        else if ((val.getType() != CBORType.ByteString) && (val.getType() != CBORType.Boolean)) throw new CoseException("Malformed key structure");
-
-        if (privKey != null && needPublic) {
-            // todo: calculate (and populate) public from private
-            pubKey = new ECPublicKeyParameters(params.getG().multiply(privKey.getD()), params);
-            byte[] rgbX = pubKey.getQ().normalize().getXCoord().getEncoded();
-            byte[] rgbY = pubKey.getQ().normalize().getYCoord().getEncoded();
-            add(KeyKeys.EC2_X, CBORObject.FromObject(rgbX));
-            add(KeyKeys.EC2_Y, CBORObject.FromObject(rgbY));
-        } else {
-            // todo: validate public on curve
-        }
-        */
+     * X9ECParameters curve = GetCurve();
+     * ECDomainParameters params = new ECDomainParameters(curve.getCurve(),
+     * curve.getG(), curve.getN(), curve.getH());
+     * boolean needPublic = false;
+     * ECPrivateKeyParameters privKey = null;
+     * ECPublicKeyParameters pubKey = null;
+     * CBORObject val;
+     *
+     * val = COSEKey.this.get(KeyKeys.EC2_D);
+     * if (val != null) {
+     * if (val.getType() != CBORType.ByteString) throw new
+     * CoseException("Malformed key structure");
+     * privKey = new ECPrivateKeyParameters(new BigInteger(1, val.GetByteString()),
+     * params);
+     * }
+     *
+     * val = COSEKey.this.get(KeyKeys.EC2_X);
+     * if (val == null) {
+     * if (privKey == null) throw new CoseException("Malformed key structure");
+     * else needPublic = true;
+     * }
+     * else if (val.getType() != CBORType.ByteString) throw new
+     * CoseException("Malformed key structure");
+     *
+     * val = COSEKey.this.get(KeyKeys.EC2_Y);
+     * if (val == null) {
+     * if (privKey == null) throw new CoseException("Malformed key structure");
+     * else needPublic = true;
+     * }
+     * else if ((val.getType() != CBORType.ByteString) && (val.getType() !=
+     * CBORType.Boolean)) throw new CoseException("Malformed key structure");
+     *
+     * if (privKey != null && needPublic) {
+     * // todo: calculate (and populate) public from private
+     * pubKey = new ECPublicKeyParameters(params.getG().multiply(privKey.getD()),
+     * params);
+     * byte[] rgbX = pubKey.getQ().normalize().getXCoord().getEncoded();
+     * byte[] rgbY = pubKey.getQ().normalize().getYCoord().getEncoded();
+     * add(KeyKeys.EC2_X, CBORObject.FromObject(rgbX));
+     * add(KeyKeys.EC2_Y, CBORObject.FromObject(rgbY));
+     * } else {
+     * // todo: validate public on curve
+     * }
+     */
   }
 
   public ECGenParameterSpec GetCurve2() throws CoseException {
-    if (
-      COSEKey.this.get(KeyKeys.KeyType) != KeyKeys.KeyType_EC2
-    ) throw new CoseException("Not an EC2 key");
-    CBORObject cnCurve = COSEKey.this.get(KeyKeys.EC2_Curve);
+    if (get(KeyKeys.KeyType) != KeyKeys.KeyType_EC2) throw new CoseException(
+      "Not an EC2 key"
+    );
+    CBORObject cnCurve = get(KeyKeys.EC2_Curve);
 
     if (cnCurve == KeyKeys.EC2_P256) return new ECGenParameterSpec("secp256r1");
     if (cnCurve == KeyKeys.EC2_P384) return new ECGenParameterSpec("secp384r1");
@@ -601,10 +621,11 @@ public class COSEKey {
 
   /**
    * Generate a random key pair based on the given algorithm.
-   * Some algorithm can take a parameter. For example, the RSA_PSS family of algorithm
+   * Some algorithm can take a parameter. For example, the RSA_PSS family of
+   * algorithm
    * can take the RSA key size as a parameter.
    *
-   * @param algorithm the algorithm to generate a key pair for
+   * @param algorithm  the algorithm to generate a key pair for
    * @param parameters optional parameters to the key pair generator
    * @return the generated Key Pair
    * @throws CoseException
@@ -616,12 +637,13 @@ public class COSEKey {
 
   /**
    * Generate a random key pair based on the given algorithm.
-   * Some algorithm can take a parameter. For example, the RSA_PSS family of algorithm
+   * Some algorithm can take a parameter. For example, the RSA_PSS family of
+   * algorithm
    * can take the RSA key size as a parameter.
    *
-   * @param algorithm the algorithm to generate a key pair for
+   * @param algorithm  the algorithm to generate a key pair for
    * @param parameters optional parameters to the key pair generator
-   * @param provider JCA provider to use
+   * @param provider   JCA provider to use
    * @return the generated Key Pair
    * @throws CoseException
    */
@@ -835,7 +857,7 @@ public class COSEKey {
   }
 
   /**
-   * Create a COSEKey object with only the public fields.  Filters out the
+   * Create a COSEKey object with only the public fields. Filters out the
    * private key fields but leaves all positive number labels and text labels
    * along with negative number labels that are public fields.
    *
@@ -860,7 +882,7 @@ public class COSEKey {
       return null;
     }
 
-    //  Allow them to use the same underlying public key object
+    // Allow them to use the same underlying public key object
 
     newKey.publicKey = publicKey;
 
@@ -920,8 +942,10 @@ public class COSEKey {
   /**
    * Return the user data field.
    *
-   * The user data object allows for an application to associate a piece of arbitrary
+   * The user data object allows for an application to associate a piece of
+   * arbitrary
    * data with a key and retrieve it later.
+   *
    * @return the user data object
    */
   public Object getUserData() {
@@ -931,8 +955,10 @@ public class COSEKey {
   /**
    * Set the user data field.
    *
-   * The user data field allows for an application to associate a piece of arbitrary
+   * The user data field allows for an application to associate a piece of
+   * arbitrary
    * data with a key and retrieve it later.
+   *
    * @param newData Data field to be saved.
    */
   public void setUserData(Object newData) {
@@ -1000,8 +1026,7 @@ public class COSEKey {
       );
 
       if (privateKey != null && needPublic) {
-        byte[] pkcs8 = privateKey.getEncoded();
-        return;
+        privateKey.getEncoded();
         // todo: calculate (and populate) public from private
       }
 

--- a/src/main/java/se/digg/cose/COSEObject.java
+++ b/src/main/java/se/digg/cose/COSEObject.java
@@ -216,7 +216,7 @@ public abstract class COSEObject extends Attribute {
     obj = EncodeCBORObject();
 
     if (emitTag) {
-      obj = CBORObject.FromObjectAndTag(obj, coseObjectTag.value);
+      obj = CBORObject.FromCBORObjectAndTag(obj, coseObjectTag.value);
     }
 
     return obj;

--- a/src/main/java/se/digg/cose/COSEObject.java
+++ b/src/main/java/se/digg/cose/COSEObject.java
@@ -12,8 +12,9 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The COSEObject class provides a common class that all of the COSE message classes
- * inherit from.  It provides the function used for decoding all of the known
+ * The COSEObject class provides a common class that all of the COSE message
+ * classes
+ * inherit from. It provides the function used for decoding all of the known
  * messages.
  *
  * @author jimsch
@@ -42,8 +43,8 @@ public abstract class COSEObject extends Attribute {
   protected byte[] rgbContent = null;
 
   /**
-   * Decode a COSE message object.  This function assumes that the message
-   * has a leading CBOR tag to identify the message type.  If this is not
+   * Decode a COSE message object. This function assumes that the message
+   * has a leading CBOR tag to identify the message type. If this is not
    * true then use {#link DecodeFromBytes(byte[], COSEObjectTag)}.
    *
    * @param rgbData byte stream to be decoded
@@ -57,10 +58,10 @@ public abstract class COSEObject extends Attribute {
 
   /**
    * Decode a COSE message object. Use a value of {@code COSEObjectTag.Unknown}
-   * to decode a generic structure with tagging.  Use a specific value if
+   * to decode a generic structure with tagging. Use a specific value if
    * the tagging is absent or if a known structure is passed in.
    *
-   * @param rgbData byte stream to be decoded
+   * @param rgbData    byte stream to be decoded
    * @param defaultTag assumed message type to be decoded
    * @return the decoded message object
    * @throws CoseException on a decode failure.
@@ -134,7 +135,7 @@ public abstract class COSEObject extends Attribute {
     if (countersignature != null) {
       if (
         (countersignature.getType() != CBORType.Array) ||
-        (countersignature.getValues().isEmpty())
+        countersignature.getValues().isEmpty()
       ) {
         throw new CoseException("Invalid countersignature attribute");
       }
@@ -146,12 +147,10 @@ public abstract class COSEObject extends Attribute {
           }
 
           CounterSign cs = new CounterSign(obj);
-          cs.setObject(msg);
           msg.addCountersignature(cs);
         }
       } else {
         CounterSign cs = new CounterSign(countersignature);
-        cs.setObject(msg);
         msg.addCountersignature(cs);
       }
     }
@@ -166,14 +165,14 @@ public abstract class COSEObject extends Attribute {
       }
 
       CounterSign1 cs = new CounterSign1(countersignature.GetByteString());
-      cs.setObject(msg);
       msg.counterSign1 = cs;
     }
     return msg;
   }
 
   /**
-   * Encode the message to a byte array.  This function will force cryptographic operations to be executed as needed.
+   * Encode the message to a byte array. This function will force cryptographic
+   * operations to be executed as needed.
    *
    * @return byte encoded object
    * @throws CoseException Internal COSE Exception
@@ -183,7 +182,8 @@ public abstract class COSEObject extends Attribute {
   }
 
   /**
-   * Given a CBOR tree, parse the message.  This is an abstract function that is implemented for each different supported COSE message.
+   * Given a CBOR tree, parse the message. This is an abstract function that is
+   * implemented for each different supported COSE message.
    *
    * @param messageObject CBORObject to be converted to a message.
    * @throws CoseException Internal COSE Exception
@@ -193,8 +193,10 @@ public abstract class COSEObject extends Attribute {
     throws CoseException;
 
   /**
-   * Encode the COSE message object to a CBORObject tree.  This function call will force cryptographic operations to be executed as needed.
-   * This is an internal function, as such it does not add the tag on the front and is implemented on a per message object.
+   * Encode the COSE message object to a CBORObject tree. This function call will
+   * force cryptographic operations to be executed as needed.
+   * This is an internal function, as such it does not add the tag on the front
+   * and is implemented on a per message object.
    *
    * @return CBORObject representing the message.
    * @throws CoseException Internal COSE Exception
@@ -202,7 +204,8 @@ public abstract class COSEObject extends Attribute {
   protected abstract CBORObject EncodeCBORObject() throws CoseException;
 
   /**
-   * Encode the COSE message object to a CBORObject tree.  This function call will force cryptographic operations to be executed as needed.
+   * Encode the COSE message object to a CBORObject tree. This function call will
+   * force cryptographic operations to be executed as needed.
    *
    * @return CBORObject representing the message.
    * @throws CoseException Internal COSE Exception
@@ -238,8 +241,9 @@ public abstract class COSEObject extends Attribute {
   }
 
   /**
-   * Set the content bytes of the message.  If the message was transmitted with
-   * detached content, this must be called before doing cryptographic processing on the message.
+   * Set the content bytes of the message. If the message was transmitted with
+   * detached content, this must be called before doing cryptographic processing
+   * on the message.
    *
    * @param rgbData bytes to set as the content
    */
@@ -248,7 +252,8 @@ public abstract class COSEObject extends Attribute {
   }
 
   /**
-   * Set the content bytes as a text string.  The string will be encoded using UTF8 into a byte string.
+   * Set the content bytes as a text string. The string will be encoded using UTF8
+   * into a byte string.
    *
    * @param strData string to set as the content
    */

--- a/src/main/java/se/digg/cose/COSEObjectTag.java
+++ b/src/main/java/se/digg/cose/COSEObjectTag.java
@@ -25,7 +25,7 @@ public enum COSEObjectTag {
   }
 
   public static COSEObjectTag FromInt(int i) throws CoseException {
-    for (COSEObjectTag m : COSEObjectTag.values()) {
+    for (COSEObjectTag m : values()) {
       if (i == m.value) return m;
     }
     throw new CoseException("Not a COSEObject tag number");

--- a/src/main/java/se/digg/cose/CounterSign.java
+++ b/src/main/java/se/digg/cose/CounterSign.java
@@ -54,15 +54,4 @@ public class CounterSign extends Signer {
 
     return validate(rgbBodyProtect, message.rgbContent);
   }
-
-  private COSEObject m_msgToSign;
-  private Signer m_signerToSign;
-
-  public void setObject(COSEObject msg) {
-    m_msgToSign = msg;
-  }
-
-  public void setObject(Signer signer) {
-    m_signerToSign = signer;
-  }
 }

--- a/src/main/java/se/digg/cose/CounterSign1.java
+++ b/src/main/java/se/digg/cose/CounterSign1.java
@@ -31,17 +31,6 @@ public class CounterSign1 extends Signer {
     objProtected.Clear();
   }
 
-  private COSEObject m_msgToSign;
-  private Signer m_signerToSign;
-
-  public void setObject(COSEObject msg) {
-    m_msgToSign = msg;
-  }
-
-  public void setObject(Signer signer) {
-    m_signerToSign = signer;
-  }
-
   public void setKey(COSEKey key) {
     cnKey = key;
   }

--- a/src/main/java/se/digg/cose/CounterSign1.java
+++ b/src/main/java/se/digg/cose/CounterSign1.java
@@ -55,6 +55,6 @@ public class CounterSign1 extends Signer {
       );
     }
 
-    return CBORObject.FromObject(rgbSignature);
+    return CBORObject.FromByteArray(rgbSignature);
   }
 }

--- a/src/main/java/se/digg/cose/Encrypt0COSEObject.java
+++ b/src/main/java/se/digg/cose/Encrypt0COSEObject.java
@@ -87,7 +87,7 @@ public class Encrypt0COSEObject extends EncryptCommon {
 
     CBORObject obj = CBORObject.NewArray();
     if (objProtected.size() > 0) obj.Add(objProtected.EncodeToBytes());
-    else obj.Add(CBORObject.FromObject(new byte[0]));
+    else obj.Add(CBORObject.FromByteArray(new byte[0]));
 
     obj.Add(objUnprotected);
 

--- a/src/main/java/se/digg/cose/EncryptCOSEObject.java
+++ b/src/main/java/se/digg/cose/EncryptCOSEObject.java
@@ -142,7 +142,7 @@ public class EncryptCOSEObject extends EncryptCommon {
 
     CBORObject obj = CBORObject.NewArray();
     if (objProtected.size() > 0) obj.Add(objProtected.EncodeToBytes());
-    else obj.Add(CBORObject.FromObject(new byte[0]));
+    else obj.Add(CBORObject.FromByteArray(new byte[0]));
 
     obj.Add(objUnprotected);
     obj.Add(rgbEncrypt);

--- a/src/main/java/se/digg/cose/EncryptCommon.java
+++ b/src/main/java/se/digg/cose/EncryptCommon.java
@@ -173,7 +173,7 @@ public abstract class EncryptCommon extends COSEObject {
     if (iv == null) {
       byte[] tmp = new byte[ivLen];
       random.nextBytes(tmp);
-      iv = CBORObject.FromObject(tmp);
+      iv = CBORObject.FromByteArray(tmp);
       addAttribute(HeaderKeys.IV, iv, UNPROTECTED);
     } else {
       if (iv.getType() != CBORType.ByteString) {
@@ -270,7 +270,7 @@ public abstract class EncryptCommon extends COSEObject {
       // generate IV
       byte[] tmp = new byte[AES_GCM_IV_LENGTH / 8];
       random.nextBytes(tmp);
-      iv = CBORObject.FromObject(tmp);
+      iv = CBORObject.FromByteArray(tmp);
       addAttribute(HeaderKeys.IV, iv, PROTECTED);
     } else {
       if (iv.getType() != CBORType.ByteString) {
@@ -310,7 +310,7 @@ public abstract class EncryptCommon extends COSEObject {
     if (objProtected.size() == 0) rgbProtected = new byte[0];
     else rgbProtected = objProtected.EncodeToBytes();
     obj.Add(rgbProtected);
-    obj.Add(CBORObject.FromObject(externalData));
+    obj.Add(CBORObject.FromByteArray(externalData));
     return obj.EncodeToBytes();
   }
 

--- a/src/main/java/se/digg/cose/HeaderKeys.java
+++ b/src/main/java/se/digg/cose/HeaderKeys.java
@@ -48,7 +48,7 @@ public enum HeaderKeys {
   private CBORObject value;
 
   HeaderKeys(int val) {
-    this.value = CBORObject.FromObject(val);
+    this.value = CBORObject.FromInt32(val);
   }
 
   public CBORObject AsCBOR() {

--- a/src/main/java/se/digg/cose/KeyKeys.java
+++ b/src/main/java/se/digg/cose/KeyKeys.java
@@ -44,22 +44,22 @@ public enum KeyKeys {
 
   private final CBORObject value;
 
-  public static final CBORObject KeyType_OKP = CBORObject.FromObject(1);
-  public static final CBORObject KeyType_EC2 = CBORObject.FromObject(2);
-  public static final CBORObject KeyType_Octet = CBORObject.FromObject(4);
-  public static final CBORObject KeyType_RSA = CBORObject.FromObject(3);
+  public static final CBORObject KeyType_OKP = CBORObject.FromInt32(1);
+  public static final CBORObject KeyType_EC2 = CBORObject.FromInt32(2);
+  public static final CBORObject KeyType_Octet = CBORObject.FromInt32(4);
+  public static final CBORObject KeyType_RSA = CBORObject.FromInt32(3);
 
-  public static final CBORObject EC2_P256 = CBORObject.FromObject(1);
-  public static final CBORObject EC2_P384 = CBORObject.FromObject(2);
-  public static final CBORObject EC2_P521 = CBORObject.FromObject(3);
+  public static final CBORObject EC2_P256 = CBORObject.FromInt32(1);
+  public static final CBORObject EC2_P384 = CBORObject.FromInt32(2);
+  public static final CBORObject EC2_P521 = CBORObject.FromInt32(3);
 
-  public static final CBORObject OKP_X25519 = CBORObject.FromObject(4);
-  public static final CBORObject OKP_X448 = CBORObject.FromObject(5);
-  public static final CBORObject OKP_Ed25519 = CBORObject.FromObject(6);
-  public static final CBORObject OKP_Ed448 = CBORObject.FromObject(7);
+  public static final CBORObject OKP_X25519 = CBORObject.FromInt32(4);
+  public static final CBORObject OKP_X448 = CBORObject.FromInt32(5);
+  public static final CBORObject OKP_Ed25519 = CBORObject.FromInt32(6);
+  public static final CBORObject OKP_Ed448 = CBORObject.FromInt32(7);
 
   KeyKeys(int val) {
-    this.value = CBORObject.FromObject(val);
+    this.value = CBORObject.FromInt32(val);
   }
 
   public CBORObject AsCBOR() {

--- a/src/main/java/se/digg/cose/KeySet.java
+++ b/src/main/java/se/digg/cose/KeySet.java
@@ -30,7 +30,9 @@ public class KeySet {
     for (int i = 0; i < keysIn.size(); i++) {
       try {
         keys.add(new COSEKey(keysIn.get(i)));
-      } catch (CoseException e) {}
+      } catch (CoseException e) {
+        System.out.println("This exception should likely be logged or handled");
+      }
     }
   }
 

--- a/src/main/java/se/digg/cose/MAC0COSEObject.java
+++ b/src/main/java/se/digg/cose/MAC0COSEObject.java
@@ -55,7 +55,7 @@ public class MAC0COSEObject extends MacCommon {
 
     CBORObject obj = CBORObject.NewArray();
     if (objProtected.size() > 0) obj.Add(objProtected.EncodeToBytes());
-    else obj.Add(CBORObject.FromObject(new byte[0]));
+    else obj.Add(CBORObject.FromByteArray(new byte[0]));
 
     obj.Add(objUnprotected);
     obj.Add(rgbContent);

--- a/src/main/java/se/digg/cose/MACCOSEObject.java
+++ b/src/main/java/se/digg/cose/MACCOSEObject.java
@@ -100,18 +100,25 @@ public class MACCOSEObject extends MacCommon {
   public boolean Validate(Recipient recipientToUse)
     throws CoseException, Exception {
     byte[] rgbKey = null;
-    int cbitKey = 0;
     AlgorithmID alg = AlgorithmID.FromCBOR(findAttribute(HeaderKeys.Algorithm));
 
     for (Recipient recipient : recipientList) {
       if (recipientToUse == null) {
         try {
           rgbKey = recipient.decrypt(alg, recipientToUse);
-        } catch (CoseException e) {}
+        } catch (CoseException e) {
+          System.out.println(
+            "This exception should likely be logged or handled "
+          );
+        }
       } else if (recipientToUse == recipient) {
         try {
           rgbKey = recipient.decrypt(alg, recipientToUse);
-        } catch (CoseException e) {}
+        } catch (CoseException e) {
+          System.out.println(
+            "This exception should likely be logged or handled "
+          );
+        }
         if (rgbKey == null) break;
       }
 

--- a/src/main/java/se/digg/cose/MACCOSEObject.java
+++ b/src/main/java/se/digg/cose/MACCOSEObject.java
@@ -82,7 +82,7 @@ public class MACCOSEObject extends MacCommon {
 
     CBORObject obj = CBORObject.NewArray();
     if (objProtected.size() > 0) obj.Add(objProtected.EncodeToBytes());
-    else obj.Add(CBORObject.FromObject(new byte[0]));
+    else obj.Add(CBORObject.FromByteArray(new byte[0]));
 
     obj.Add(objUnprotected);
     obj.Add(rgbContent);

--- a/src/main/java/se/digg/cose/MacCommon.java
+++ b/src/main/java/se/digg/cose/MacCommon.java
@@ -34,7 +34,7 @@ public abstract class MacCommon extends COSEObject {
   }
 
   protected void CreateWithKey(byte[] rgbKey) throws CoseException {
-    CBORObject algX = findAttribute(CBORObject.FromObject(1)); //HeaderKeys.Algorithm);
+    CBORObject algX = findAttribute(CBORObject.FromInt32(1)); //HeaderKeys.Algorithm);
     AlgorithmID alg = AlgorithmID.FromCBOR(algX);
 
     if (rgbContent == null) throw new CoseException("No Content Specified");
@@ -64,7 +64,7 @@ public abstract class MacCommon extends COSEObject {
     int i;
     byte[] rgbTest;
 
-    CBORObject algX = findAttribute(CBORObject.FromObject(1)); //HeaderKeys.Algorithm);
+    CBORObject algX = findAttribute(CBORObject.FromInt32(1)); //HeaderKeys.Algorithm);
     AlgorithmID alg = AlgorithmID.FromCBOR(algX);
 
     switch (alg) {
@@ -102,8 +102,8 @@ public abstract class MacCommon extends COSEObject {
 
     obj.Add(strContext);
     obj.Add(rgbProtected);
-    if (externalData != null) obj.Add(CBORObject.FromObject(externalData));
-    else obj.Add(CBORObject.FromObject(new byte[0]));
+    if (externalData != null) obj.Add(CBORObject.FromByteArray(externalData));
+    else obj.Add(CBORObject.FromByteArray(new byte[0]));
     obj.Add(rgbContent);
 
     return obj.EncodeToBytes();

--- a/src/main/java/se/digg/cose/MacCommon.java
+++ b/src/main/java/se/digg/cose/MacCommon.java
@@ -132,7 +132,6 @@ public abstract class MacCommon extends COSEObject {
       );
       byte[] val = BuildContentBytes();
       int blockLen = cbcmac.getBlockSize();
-      int tagLen = alg.getTagSize() / 8;
 
       int dataLen = val.length, dataPad = 16 - (val.length % 16);
       if (dataPad != 16) {

--- a/src/main/java/se/digg/cose/Recipient.java
+++ b/src/main/java/se/digg/cose/Recipient.java
@@ -77,7 +77,7 @@ public class Recipient extends COSEObject {
   protected CBORObject EncodeCBORObject() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
     if (objProtected.size() > 0) obj.Add(objProtected.EncodeToBytes());
-    else obj.Add(CBORObject.FromObject(new byte[0]));
+    else obj.Add(CBORObject.FromByteArray(new byte[0]));
 
     obj.Add(objUnprotected);
     obj.Add(rgbEncrypted);
@@ -273,7 +273,7 @@ public class Recipient extends COSEObject {
           random.nextBytes(rgbAPU);
           addAttribute(
             HeaderKeys.HKDF_Context_PartyU_nonce.AsCBOR(),
-            CBORObject.FromObject(rgbAPU),
+            CBORObject.FromByteArray(rgbAPU),
             UNPROTECTED
           );
         }
@@ -302,7 +302,7 @@ public class Recipient extends COSEObject {
           random.nextBytes(rgbAPU);
           addAttribute(
             HeaderKeys.HKDF_Context_PartyU_nonce.AsCBOR(),
-            CBORObject.FromObject(rgbAPU),
+            CBORObject.FromByteArray(rgbAPU),
             UNPROTECTED
           );
         }
@@ -331,7 +331,7 @@ public class Recipient extends COSEObject {
           random.nextBytes(rgbAPU);
           addAttribute(
             HeaderKeys.HKDF_Context_PartyU_nonce.AsCBOR(),
-            CBORObject.FromObject(rgbAPU),
+            CBORObject.FromByteArray(rgbAPU),
             UNPROTECTED
           );
         }
@@ -433,7 +433,7 @@ public class Recipient extends COSEObject {
           random.nextBytes(rgbAPU);
           addAttribute(
             HeaderKeys.HKDF_Context_PartyU_nonce.AsCBOR(),
-            CBORObject.FromObject(rgbAPU),
+            CBORObject.FromByteArray(rgbAPU),
             UNPROTECTED
           );
         }
@@ -451,7 +451,7 @@ public class Recipient extends COSEObject {
           random.nextBytes(rgbAPU);
           addAttribute(
             HeaderKeys.HKDF_Context_PartyU_nonce.AsCBOR(),
-            CBORObject.FromObject(rgbAPU),
+            CBORObject.FromByteArray(rgbAPU),
             UNPROTECTED
           );
         }
@@ -700,7 +700,7 @@ public class Recipient extends COSEObject {
     //  fourth element is - Supplimental Public Info
     info = CBORObject.NewArray();
     contextArray.Add(info);
-    info.Add(CBORObject.FromObject(cbitKey));
+    info.Add(CBORObject.FromInt32(cbitKey));
     if (objProtected.size() == 0) info.Add(new byte[0]);
     else info.Add(objProtected.EncodeToBytes());
     obj = findAttribute(HeaderKeys.HKDF_SuppPub_Other.AsCBOR());

--- a/src/main/java/se/digg/cose/Sign1COSEObject.java
+++ b/src/main/java/se/digg/cose/Sign1COSEObject.java
@@ -94,7 +94,7 @@ public class Sign1COSEObject extends SignCommon {
     CBORObject obj = CBORObject.NewArray();
     obj.Add(contextString);
     if (objProtected.size() > 0) obj.Add(rgbProtected);
-    else obj.Add(CBORObject.FromObject(new byte[0]));
+    else obj.Add(CBORObject.FromByteArray(new byte[0]));
     obj.Add(externalData);
     obj.Add(rgbContent);
     return validateSignature(obj.EncodeToBytes(), rgbSignature, cnKey);

--- a/src/main/java/se/digg/cose/Signer.java
+++ b/src/main/java/se/digg/cose/Signer.java
@@ -134,7 +134,7 @@ public class Signer extends Attribute {
     if (countersignature != null) {
       if (
         (countersignature.getType() != CBORType.Array) ||
-        (countersignature.getValues().isEmpty())
+        countersignature.getValues().isEmpty()
       ) {
         throw new CoseException("Invalid countersignature attribute");
       }
@@ -146,12 +146,10 @@ public class Signer extends Attribute {
           }
 
           CounterSign cs = new CounterSign(csObj);
-          cs.setObject(this);
           this.addCountersignature(cs);
         }
       } else {
         CounterSign cs = new CounterSign(countersignature);
-        cs.setObject(this);
         this.addCountersignature(cs);
       }
     }
@@ -166,7 +164,6 @@ public class Signer extends Attribute {
       }
 
       CounterSign1 cs = new CounterSign1(countersignature.GetByteString());
-      cs.setObject(this);
       this.counterSign1 = cs;
     }
   }

--- a/src/test/java/se/digg/cose/AttributeTest.java
+++ b/src/test/java/se/digg/cose/AttributeTest.java
@@ -41,7 +41,7 @@ public class AttributeTest extends TestBase {
 
   @Test
   public void testAddAttribute_1() throws Exception {
-    CBORObject label = CBORObject.FromObject(new byte[1]);
+    CBORObject label = CBORObject.FromByteArray(new byte[1]);
     CBORObject value = null;
     int where = Attribute.PROTECTED;
     Attribute instance = new Attribute();
@@ -54,8 +54,8 @@ public class AttributeTest extends TestBase {
 
   @Test
   public void testAddAttribute_2() throws Exception {
-    CBORObject label = CBORObject.FromObject(1);
-    CBORObject value = CBORObject.FromObject(2);
+    CBORObject label = CBORObject.FromInt32(1);
+    CBORObject value = CBORObject.FromInt32(2);
     int where = 0;
     Attribute instance = new Attribute();
 

--- a/src/test/java/se/digg/cose/AttributeTest.java
+++ b/src/test/java/se/digg/cose/AttributeTest.java
@@ -5,7 +5,7 @@
 
 package se.digg.cose;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertSame;
 
 import com.upokecenter.cbor.CBORObject;
 import org.junit.After;
@@ -15,11 +15,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import se.digg.cose.AlgorithmID;
-import se.digg.cose.Attribute;
-import se.digg.cose.CoseException;
-import se.digg.cose.HeaderKeys;
-import se.digg.cose.MAC0COSEObject;
 
 /**
  *
@@ -118,30 +113,27 @@ public class AttributeTest extends TestBase {
 
     cn = instance.findAttribute(HeaderKeys.Algorithm, Attribute.PROTECTED);
     assertSame(cn, AlgorithmID.AES_CBC_MAC_128_128.AsCBOR());
-    assert (null ==
-      instance.findAttribute(HeaderKeys.Algorithm, Attribute.UNPROTECTED));
-    assert (null ==
-      instance.findAttribute(HeaderKeys.Algorithm, Attribute.DO_NOT_SEND));
+    assert null ==
+    instance.findAttribute(HeaderKeys.Algorithm, Attribute.UNPROTECTED);
+    assert null ==
+    instance.findAttribute(HeaderKeys.Algorithm, Attribute.DO_NOT_SEND);
 
     cn = instance.findAttribute(HeaderKeys.CONTENT_TYPE, Attribute.UNPROTECTED);
     assertSame(cn, AlgorithmID.AES_CBC_MAC_128_64.AsCBOR());
-    assert (null ==
-      instance.findAttribute(HeaderKeys.CONTENT_TYPE, Attribute.PROTECTED));
-    assert (null ==
-      instance.findAttribute(HeaderKeys.CONTENT_TYPE, Attribute.DO_NOT_SEND));
+    assert null ==
+    instance.findAttribute(HeaderKeys.CONTENT_TYPE, Attribute.PROTECTED);
+    assert null ==
+    instance.findAttribute(HeaderKeys.CONTENT_TYPE, Attribute.DO_NOT_SEND);
 
     cn = instance.findAttribute(
       HeaderKeys.CounterSignature,
       Attribute.DO_NOT_SEND
     );
     assertSame(cn, AlgorithmID.AES_CBC_MAC_256_64.AsCBOR());
-    assert (null ==
-      instance.findAttribute(
-        HeaderKeys.CounterSignature,
-        Attribute.UNPROTECTED
-      ));
-    assert (null ==
-      instance.findAttribute(HeaderKeys.CounterSignature, Attribute.PROTECTED));
+    assert null ==
+    instance.findAttribute(HeaderKeys.CounterSignature, Attribute.UNPROTECTED);
+    assert null ==
+    instance.findAttribute(HeaderKeys.CounterSignature, Attribute.PROTECTED);
   }
 
   @Test
@@ -174,17 +166,17 @@ public class AttributeTest extends TestBase {
 
     cn = instance.findAttribute(HeaderKeys.Algorithm, Attribute.PROTECTED);
     assertSame(cn, AlgorithmID.ECDSA_256.AsCBOR());
-    assert (null ==
-      instance.findAttribute(HeaderKeys.Algorithm, Attribute.UNPROTECTED));
-    assert (null ==
-      instance.findAttribute(HeaderKeys.Algorithm, Attribute.DO_NOT_SEND));
+    assert null ==
+    instance.findAttribute(HeaderKeys.Algorithm, Attribute.UNPROTECTED);
+    assert null ==
+    instance.findAttribute(HeaderKeys.Algorithm, Attribute.DO_NOT_SEND);
 
     cn = instance.findAttribute(HeaderKeys.CONTENT_TYPE, Attribute.PROTECTED);
     assertSame(cn, AlgorithmID.ECDH_ES_HKDF_256.AsCBOR());
-    assert (null ==
-      instance.findAttribute(HeaderKeys.CONTENT_TYPE, Attribute.UNPROTECTED));
-    assert (null ==
-      instance.findAttribute(HeaderKeys.CONTENT_TYPE, Attribute.DO_NOT_SEND));
+    assert null ==
+    instance.findAttribute(HeaderKeys.CONTENT_TYPE, Attribute.UNPROTECTED);
+    assert null ==
+    instance.findAttribute(HeaderKeys.CONTENT_TYPE, Attribute.DO_NOT_SEND);
   }
 
   @Test
@@ -203,6 +195,6 @@ public class AttributeTest extends TestBase {
 
     instance.removeAttribute(HeaderKeys.Algorithm);
     cn = instance.findAttribute(HeaderKeys.Algorithm);
-    assert (cn == null);
+    assert cn == null;
   }
 }

--- a/src/test/java/se/digg/cose/COSEKeyTest.java
+++ b/src/test/java/se/digg/cose/COSEKeyTest.java
@@ -5,7 +5,9 @@
 
 package se.digg.cose;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import com.upokecenter.cbor.CBORObject;
 import com.upokecenter.cbor.CBORType;
@@ -29,10 +31,6 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
-import se.digg.cose.AlgorithmID;
-import se.digg.cose.COSEKey;
-import se.digg.cose.CoseException;
-import se.digg.cose.KeyKeys;
 
 /**
  *
@@ -190,7 +188,7 @@ public class COSEKeyTest extends TestBase {
     assertEquals(result.getFormat(), "X.509");
 
     byte[] rgbSPKI = result.getEncoded();
-    String f = byteArrayToHex(rgbSPKI);
+    byteArrayToHex(rgbSPKI);
     assertEquals(rgbSPKI.length, 91);
 
     KeyFactory kFactory = KeyFactory.getInstance(
@@ -198,7 +196,7 @@ public class COSEKeyTest extends TestBase {
       new BouncyCastleProvider()
     );
     X509EncodedKeySpec spec = new X509EncodedKeySpec(rgbSPKI);
-    PublicKey pubKey = (PublicKey) kFactory.generatePublic(spec);
+    kFactory.generatePublic(spec);
   }
 
   /**
@@ -214,7 +212,7 @@ public class COSEKeyTest extends TestBase {
     assertEquals(result.getFormat(), "PKCS#8");
 
     byte[] rgbPrivate = result.getEncoded();
-    String x = byteArrayToHex(rgbPrivate);
+    byteArrayToHex(rgbPrivate);
 
     /*
         
@@ -229,7 +227,7 @@ public class COSEKeyTest extends TestBase {
     );
 
     PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(rgbPrivate);
-    PrivateKey pubKey = (PrivateKey) kFactory.generatePrivate(spec);
+    kFactory.generatePrivate(spec);
   }
 
   @Test
@@ -297,9 +295,9 @@ public class COSEKeyTest extends TestBase {
 
     KeyPair keyPair = gen.genKeyPair();
 
-    COSEKey pubKey = new COSEKey(keyPair.getPublic(), null);
-    COSEKey privKey = new COSEKey(null, keyPair.getPrivate());
-    COSEKey bothKey = new COSEKey(keyPair.getPublic(), keyPair.getPrivate());
+    new COSEKey(keyPair.getPublic(), null);
+    new COSEKey(null, keyPair.getPrivate());
+    new COSEKey(keyPair.getPublic(), keyPair.getPrivate());
   }
 
   @Test

--- a/src/test/java/se/digg/cose/COSEKeyTest.java
+++ b/src/test/java/se/digg/cose/COSEKeyTest.java
@@ -255,9 +255,9 @@ public class COSEKeyTest extends TestBase {
     String idStr = "testId";
     byte[] bStr = StandardCharsets.UTF_8.encode(idStr).array();
     COSEKey key = new COSEKey();
-    CBORObject id = CBORObject.FromObject(bStr);
+    CBORObject id = CBORObject.FromByteArray(bStr);
     key.add(KeyKeys.KeyId, id);
-    Assert.assertTrue(key.HasKeyID(idStr));
+    Assert.assertTrue(key.HasKeyID(idStr.getBytes()));
     Assert.assertTrue(key.HasKeyID(bStr));
   }
 
@@ -270,7 +270,7 @@ public class COSEKeyTest extends TestBase {
   @Test
   public void testHasKeyOp_value() {
     COSEKey key = new COSEKey();
-    key.add(KeyKeys.Key_Ops, CBORObject.FromObject(2));
+    key.add(KeyKeys.Key_Ops, CBORObject.FromInt32(2));
     Assert.assertTrue(key.HasKeyOp(2));
   }
 

--- a/src/test/java/se/digg/cose/COSEObjectTest.java
+++ b/src/test/java/se/digg/cose/COSEObjectTest.java
@@ -5,7 +5,8 @@
 
 package se.digg.cose;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 import com.upokecenter.cbor.CBORObject;
 import org.junit.After;
@@ -15,13 +16,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import se.digg.cose.AlgorithmID;
-import se.digg.cose.Attribute;
-import se.digg.cose.COSEObject;
-import se.digg.cose.COSEObjectTag;
-import se.digg.cose.CoseException;
-import se.digg.cose.Encrypt0COSEObject;
-import se.digg.cose.HeaderKeys;
 
 /**
  *

--- a/src/test/java/se/digg/cose/COSEObjectTest.java
+++ b/src/test/java/se/digg/cose/COSEObjectTest.java
@@ -74,7 +74,7 @@ public class COSEObjectTest extends TestBase {
     );
     msg.addAttribute(
       HeaderKeys.IV,
-      CBORObject.FromObject(rgbIV96),
+      CBORObject.FromByteArray(rgbIV96),
       Attribute.PROTECTED
     );
     msg.SetContent(rgbContent);
@@ -105,7 +105,7 @@ public class COSEObjectTest extends TestBase {
     );
     msg.addAttribute(
       HeaderKeys.IV,
-      CBORObject.FromObject(rgbIV96),
+      CBORObject.FromByteArray(rgbIV96),
       Attribute.PROTECTED
     );
     msg.SetContent(rgbContent);

--- a/src/test/java/se/digg/cose/CounterSignTest.java
+++ b/src/test/java/se/digg/cose/CounterSignTest.java
@@ -13,8 +13,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import se.digg.cose.CoseException;
-import se.digg.cose.CounterSign;
 
 /**
  *

--- a/src/test/java/se/digg/cose/CounterSignTest.java
+++ b/src/test/java/se/digg/cose/CounterSignTest.java
@@ -80,7 +80,7 @@ public class CounterSignTest extends TestBase {
   @Test
   public void signerDecodeBadProtected2() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.False));
+    obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
 
@@ -95,7 +95,7 @@ public class CounterSignTest extends TestBase {
   @Test
   public void signerDecodeBadUnprotected() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
 
@@ -110,7 +110,7 @@ public class CounterSignTest extends TestBase {
   @Test
   public void signerDecodeBadSignature() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.NewMap());
     obj.Add(CBORObject.False);
 

--- a/src/test/java/se/digg/cose/Encrypt0COSEObjectTest.java
+++ b/src/test/java/se/digg/cose/Encrypt0COSEObjectTest.java
@@ -5,18 +5,16 @@
 
 package se.digg.cose;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
 
 import com.upokecenter.cbor.CBORObject;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import se.digg.cose.AlgorithmID;
-import se.digg.cose.Attribute;
-import se.digg.cose.COSEObject;
-import se.digg.cose.COSEObjectTag;
-import se.digg.cose.CoseException;
-import se.digg.cose.Encrypt0COSEObject;
-import se.digg.cose.HeaderKeys;
 
 /**
  *
@@ -285,7 +283,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
     msg.encrypt(rgbKey128);
     CBORObject cn = msg.EncodeCBORObject();
 
-    assert (!cn.isTagged());
+    assert !cn.isTagged();
   }
 
   @Test
@@ -306,7 +304,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
     msg.encrypt(rgbKey128);
     CBORObject cn = msg.EncodeCBORObject();
 
-    assert (cn.get(2).isNull());
+    assert cn.get(2).isNull();
   }
 
   @Test
@@ -370,7 +368,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
     thrown.expectMessage("COSEObject is not a COSE security COSEObject");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt0);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt0);
   }
 
   @Test
@@ -382,7 +380,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Encrypt0 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt0);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt0);
   }
 
   @Test
@@ -396,7 +394,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Encrypt0 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt0);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt0);
   }
 
   @Test
@@ -410,7 +408,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Encrypt0 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt0);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt0);
   }
 
   @Test
@@ -424,7 +422,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Encrypt0 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt0);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt0);
   }
 
   @Test
@@ -438,7 +436,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Encrypt0 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt0);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt0);
   }
 
   @Test
@@ -452,6 +450,6 @@ public class Encrypt0COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Encrypt0 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt0);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt0);
   }
 }

--- a/src/test/java/se/digg/cose/Encrypt0COSEObjectTest.java
+++ b/src/test/java/se/digg/cose/Encrypt0COSEObjectTest.java
@@ -130,7 +130,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
     );
     msg.addAttribute(
       HeaderKeys.IV,
-      CBORObject.FromObject(rgbIV96),
+      CBORObject.FromByteArray(rgbIV96),
       Attribute.PROTECTED
     );
     msg.SetContent(rgbContent);
@@ -164,7 +164,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
     thrown.expectMessage("Unknown Algorithm Specified");
     msg.addAttribute(
       HeaderKeys.Algorithm,
-      CBORObject.FromObject("Unknown"),
+      CBORObject.FromString("Unknown"),
       Attribute.PROTECTED
     );
     msg.SetContent(rgbContent);
@@ -242,7 +242,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
     );
     msg.addAttribute(
       HeaderKeys.IV,
-      CBORObject.FromObject("IV"),
+      CBORObject.FromString("IV"),
       Attribute.UNPROTECTED
     );
     msg.SetContent(rgbContent);
@@ -276,7 +276,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
     );
     msg.addAttribute(
       HeaderKeys.IV,
-      CBORObject.FromObject(rgbIV96),
+      CBORObject.FromByteArray(rgbIV96),
       Attribute.PROTECTED
     );
     msg.SetContent(rgbContent);
@@ -297,7 +297,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
     );
     msg.addAttribute(
       HeaderKeys.IV,
-      CBORObject.FromObject(rgbIV96),
+      CBORObject.FromByteArray(rgbIV96),
       Attribute.UNPROTECTED
     );
     msg.SetContent(rgbContent);
@@ -322,7 +322,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
     );
     msg.addAttribute(
       HeaderKeys.IV,
-      CBORObject.FromObject(rgbIV96),
+      CBORObject.FromByteArray(rgbIV96),
       Attribute.UNPROTECTED
     );
     msg.SetContent(rgbContent);
@@ -345,7 +345,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
     );
     msg.addAttribute(
       HeaderKeys.IV,
-      CBORObject.FromObject(rgbIV96),
+      CBORObject.FromByteArray(rgbIV96),
       Attribute.UNPROTECTED
     );
     msg.SetContent(rgbContent);
@@ -400,7 +400,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
   @Test
   public void encryptDecodeBadProtected2() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.False));
+    obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
 
@@ -414,7 +414,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
   @Test
   public void encryptDecodeBadUnprotected() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
 
@@ -428,7 +428,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
   @Test
   public void encryptDecodeBadContent() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.NewMap());
     obj.Add(CBORObject.False);
 
@@ -442,7 +442,7 @@ public class Encrypt0COSEObjectTest extends TestBase {
   @Test
   public void encryptDecodeBadTag() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.NewMap());
     obj.Add(new byte[0]);
 

--- a/src/test/java/se/digg/cose/EncryptCOSEObjectTest.java
+++ b/src/test/java/se/digg/cose/EncryptCOSEObjectTest.java
@@ -132,7 +132,7 @@ public class EncryptCOSEObjectTest extends TestBase {
     );
     CBORObject key128 = CBORObject.NewMap();
     key128.Add(KeyKeys.KeyType.AsCBOR(), KeyKeys.KeyType_Octet);
-    key128.Add(KeyKeys.Octet_K.AsCBOR(), CBORObject.FromObject(rgbKey128));
+    key128.Add(KeyKeys.Octet_K.AsCBOR(), CBORObject.FromByteArray(rgbKey128));
     cnKey128 = new COSEKey(key128);
     recipient128.SetKey(cnKey128);
   }
@@ -151,7 +151,7 @@ public class EncryptCOSEObjectTest extends TestBase {
     );
     msg.addAttribute(
       HeaderKeys.IV,
-      CBORObject.FromObject(rgbIV96),
+      CBORObject.FromByteArray(rgbIV96),
       Attribute.PROTECTED
     );
     msg.SetContent(rgbContent);
@@ -223,7 +223,7 @@ public class EncryptCOSEObjectTest extends TestBase {
     thrown.expectMessage("Unknown Algorithm Specified");
     msg.addAttribute(
       HeaderKeys.Algorithm,
-      CBORObject.FromObject("Unknown"),
+      CBORObject.FromString("Unknown"),
       Attribute.PROTECTED
     );
     msg.SetContent(rgbContent);
@@ -278,7 +278,7 @@ public class EncryptCOSEObjectTest extends TestBase {
     );
     msg.addAttribute(
       HeaderKeys.IV,
-      CBORObject.FromObject("IV"),
+      CBORObject.FromString("IV"),
       Attribute.UNPROTECTED
     );
     msg.SetContent(rgbContent);
@@ -344,7 +344,7 @@ public class EncryptCOSEObjectTest extends TestBase {
   @Test
   public void encryptDecodeBadProtected2() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.False));
+    obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
@@ -359,7 +359,7 @@ public class EncryptCOSEObjectTest extends TestBase {
   @Test
   public void encryptDecodeBadUnprotected() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
@@ -374,7 +374,7 @@ public class EncryptCOSEObjectTest extends TestBase {
   @Test
   public void encryptDecodeBadContent() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.NewMap());
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
@@ -389,7 +389,7 @@ public class EncryptCOSEObjectTest extends TestBase {
   @Test
   public void encryptDecodeBadRecipients() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.NewMap());
     obj.Add(new byte[0]);
     obj.Add(CBORObject.False);

--- a/src/test/java/se/digg/cose/EncryptCOSEObjectTest.java
+++ b/src/test/java/se/digg/cose/EncryptCOSEObjectTest.java
@@ -5,23 +5,16 @@
 
 package se.digg.cose;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
-import com.upokecenter.cbor.*;
+import com.upokecenter.cbor.CBORObject;
 import java.util.List;
 import org.bouncycastle.crypto.InvalidCipherTextException;
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import se.digg.cose.AlgorithmID;
-import se.digg.cose.Attribute;
-import se.digg.cose.COSEKey;
-import se.digg.cose.COSEObject;
-import se.digg.cose.COSEObjectTag;
-import se.digg.cose.CoseException;
-import se.digg.cose.EncryptCOSEObject;
-import se.digg.cose.HeaderKeys;
-import se.digg.cose.KeyKeys;
-import se.digg.cose.Recipient;
 
 /**
  *
@@ -318,7 +311,7 @@ public class EncryptCOSEObjectTest extends TestBase {
     thrown.expectMessage("COSEObject is not a COSE security COSEObject");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt);
   }
 
   @Test
@@ -330,7 +323,7 @@ public class EncryptCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Encrypt structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt);
   }
 
   @Test
@@ -345,7 +338,7 @@ public class EncryptCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Encrypt structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt);
   }
 
   @Test
@@ -360,7 +353,7 @@ public class EncryptCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Encrypt structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt);
   }
 
   @Test
@@ -375,7 +368,7 @@ public class EncryptCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Encrypt structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt);
   }
 
   @Test
@@ -390,7 +383,7 @@ public class EncryptCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Encrypt structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt);
   }
 
   @Test
@@ -405,6 +398,6 @@ public class EncryptCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Encrypt structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Encrypt);
   }
 }

--- a/src/test/java/se/digg/cose/KeySetTest.java
+++ b/src/test/java/se/digg/cose/KeySetTest.java
@@ -8,12 +8,6 @@ package se.digg.cose;
 import java.util.List;
 import org.junit.Assert;
 import org.junit.Test;
-import se.digg.cose.AlgorithmID;
-import se.digg.cose.COSEKey;
-import se.digg.cose.CoseException;
-import se.digg.cose.KeyKeys;
-import se.digg.cose.KeySet;
-import se.digg.cose.KeySetCollector;
 
 public class KeySetTest extends TestBase {
 

--- a/src/test/java/se/digg/cose/MAC0COSEObjectTest.java
+++ b/src/test/java/se/digg/cose/MAC0COSEObjectTest.java
@@ -106,7 +106,7 @@ public class MAC0COSEObjectTest extends TestBase {
   public void setUp() {
     cnKey256 = CBORObject.NewMap();
     cnKey256.Add(KeyKeys.KeyType.AsCBOR(), KeyKeys.KeyType_Octet);
-    cnKey256.Add(KeyKeys.Octet_K.AsCBOR(), CBORObject.FromObject(rgbKey256));
+    cnKey256.Add(KeyKeys.Octet_K.AsCBOR(), CBORObject.FromByteArray(rgbKey256));
   }
 
   @After
@@ -156,7 +156,7 @@ public class MAC0COSEObjectTest extends TestBase {
     thrown.expectMessage("Unknown Algorithm Specified");
     msg.addAttribute(
       HeaderKeys.Algorithm,
-      CBORObject.FromObject("Unknown"),
+      CBORObject.FromString("Unknown"),
       Attribute.PROTECTED
     );
     msg.SetContent(rgbContent);
@@ -233,7 +233,7 @@ public class MAC0COSEObjectTest extends TestBase {
   @Test
   public void macDecodeBadProtected2() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.False));
+    obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
@@ -248,7 +248,7 @@ public class MAC0COSEObjectTest extends TestBase {
   @Test
   public void macDecodeBadUnprotected() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
@@ -263,7 +263,7 @@ public class MAC0COSEObjectTest extends TestBase {
   @Test
   public void macDecodeBadContent() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.NewMap());
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
@@ -278,7 +278,7 @@ public class MAC0COSEObjectTest extends TestBase {
   @Test
   public void macDecodeBadRecipients() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.NewMap());
     obj.Add(new byte[0]);
     obj.Add(CBORObject.False);

--- a/src/test/java/se/digg/cose/MAC0COSEObjectTest.java
+++ b/src/test/java/se/digg/cose/MAC0COSEObjectTest.java
@@ -5,19 +5,14 @@
 
 package se.digg.cose;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 import com.upokecenter.cbor.CBORObject;
-import org.junit.*;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import se.digg.cose.AlgorithmID;
-import se.digg.cose.Attribute;
-import se.digg.cose.COSEObject;
-import se.digg.cose.COSEObjectTag;
-import se.digg.cose.CoseException;
-import se.digg.cose.HeaderKeys;
-import se.digg.cose.KeyKeys;
-import se.digg.cose.MAC0COSEObject;
 
 /**
  *
@@ -205,7 +200,7 @@ public class MAC0COSEObjectTest extends TestBase {
     thrown.expectMessage("COSEObject is not a COSE security COSEObject");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC0);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC0);
   }
 
   @Test
@@ -217,7 +212,7 @@ public class MAC0COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid MAC0 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC0);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC0);
   }
 
   @Test
@@ -232,7 +227,7 @@ public class MAC0COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid MAC0 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC0);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC0);
   }
 
   @Test
@@ -247,7 +242,7 @@ public class MAC0COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid MAC0 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC0);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC0);
   }
 
   @Test
@@ -262,7 +257,7 @@ public class MAC0COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid MAC0 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC0);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC0);
   }
 
   @Test
@@ -277,7 +272,7 @@ public class MAC0COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid MAC0 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC0);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC0);
   }
 
   @Test
@@ -292,6 +287,6 @@ public class MAC0COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid MAC0 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC0);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC0);
   }
 }

--- a/src/test/java/se/digg/cose/MACCOSEObjectTest.java
+++ b/src/test/java/se/digg/cose/MACCOSEObjectTest.java
@@ -5,7 +5,8 @@
 
 package se.digg.cose;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.upokecenter.cbor.CBORObject;
 import org.junit.After;
@@ -15,16 +16,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import se.digg.cose.AlgorithmID;
-import se.digg.cose.Attribute;
-import se.digg.cose.COSEKey;
-import se.digg.cose.COSEObject;
-import se.digg.cose.COSEObjectTag;
-import se.digg.cose.CoseException;
-import se.digg.cose.HeaderKeys;
-import se.digg.cose.KeyKeys;
-import se.digg.cose.MACCOSEObject;
-import se.digg.cose.Recipient;
 
 /**
  *
@@ -285,7 +276,7 @@ public class MACCOSEObjectTest extends TestBase {
     thrown.expectMessage("COSEObject is not a COSE security COSEObject");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC);
   }
 
   @Test
@@ -297,7 +288,7 @@ public class MACCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid MAC structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC);
   }
 
   @Test
@@ -313,7 +304,7 @@ public class MACCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid MAC structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC);
   }
 
   @Test
@@ -329,7 +320,7 @@ public class MACCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid MAC structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC);
   }
 
   @Test
@@ -345,7 +336,7 @@ public class MACCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid MAC structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC);
   }
 
   @Test
@@ -361,7 +352,7 @@ public class MACCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid MAC structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC);
   }
 
   @Test
@@ -377,7 +368,7 @@ public class MACCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid MAC structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC);
   }
 
   @Test
@@ -393,6 +384,6 @@ public class MACCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid MAC structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.MAC);
   }
 }

--- a/src/test/java/se/digg/cose/MACCOSEObjectTest.java
+++ b/src/test/java/se/digg/cose/MACCOSEObjectTest.java
@@ -122,7 +122,7 @@ public class MACCOSEObjectTest extends TestBase {
     );
     CBORObject key256 = CBORObject.NewMap();
     key256.Add(KeyKeys.KeyType.AsCBOR(), KeyKeys.KeyType_Octet);
-    key256.Add(KeyKeys.Octet_K.AsCBOR(), CBORObject.FromObject(rgbKey256));
+    key256.Add(KeyKeys.Octet_K.AsCBOR(), CBORObject.FromByteArray(rgbKey256));
     cnKey256 = new COSEKey(key256);
     recipient256.SetKey(cnKey256);
   }
@@ -230,7 +230,7 @@ public class MACCOSEObjectTest extends TestBase {
     thrown.expectMessage("Unknown Algorithm Specified");
     msg.addAttribute(
       HeaderKeys.Algorithm,
-      CBORObject.FromObject("Unknown"),
+      CBORObject.FromString("Unknown"),
       Attribute.PROTECTED
     );
     msg.SetContent(rgbContent);
@@ -310,7 +310,7 @@ public class MACCOSEObjectTest extends TestBase {
   @Test
   public void macDecodeBadProtected2() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.False));
+    obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
@@ -326,7 +326,7 @@ public class MACCOSEObjectTest extends TestBase {
   @Test
   public void macDecodeBadUnprotected() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
@@ -342,7 +342,7 @@ public class MACCOSEObjectTest extends TestBase {
   @Test
   public void macDecodeBadContent() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.NewMap());
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
@@ -358,9 +358,9 @@ public class MACCOSEObjectTest extends TestBase {
   @Test
   public void macDecodeBadTag() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.NewMap());
-    obj.Add(CBORObject.FromObject(rgbContent));
+    obj.Add(CBORObject.FromByteArray(rgbContent));
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
 
@@ -374,10 +374,10 @@ public class MACCOSEObjectTest extends TestBase {
   @Test
   public void macDecodeBadRecipients() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.NewMap());
-    obj.Add(CBORObject.FromObject(rgbContent));
-    obj.Add(CBORObject.FromObject(rgbContent));
+    obj.Add(CBORObject.FromByteArray(rgbContent));
+    obj.Add(CBORObject.FromByteArray(rgbContent));
     obj.Add(CBORObject.False);
 
     thrown.expect(CoseException.class);

--- a/src/test/java/se/digg/cose/RegressionTest.java
+++ b/src/test/java/se/digg/cose/RegressionTest.java
@@ -17,28 +17,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
-import org.junit.*;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.*;
-import se.digg.cose.AlgorithmID;
-import se.digg.cose.Attribute;
-import se.digg.cose.COSEKey;
-import se.digg.cose.COSEObject;
-import se.digg.cose.COSEObjectTag;
-import se.digg.cose.CoseException;
-import se.digg.cose.CounterSign;
-import se.digg.cose.CounterSign1;
-import se.digg.cose.Encrypt0COSEObject;
-import se.digg.cose.EncryptCOSEObject;
-import se.digg.cose.HeaderKeys;
-import se.digg.cose.KeyKeys;
-import se.digg.cose.MAC0COSEObject;
-import se.digg.cose.MACCOSEObject;
-import se.digg.cose.Recipient;
-import se.digg.cose.Sign1COSEObject;
-import se.digg.cose.SignCOSEObject;
-import se.digg.cose.Signer;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
 
 /**
  *
@@ -203,7 +186,6 @@ public class RegressionTest extends TestBase {
   public void _VerifyEncrypt(CBORObject control, byte[] rgbData)
     throws CoseException {
     CBORObject cnInput = control.get("input");
-    boolean fFail = false;
     boolean fFailBody = false;
 
     CBORObject cnFail = control.get("fail");
@@ -326,8 +308,6 @@ public class RegressionTest extends TestBase {
     byte[] rgb = hEncObj.EncodeToBytes();
 
     _VerifyMac(cnControl, rgb);
-
-    return;
   }
 
   public void BuildMac0Test(CBORObject cnControl)
@@ -381,8 +361,6 @@ public class RegressionTest extends TestBase {
   public void _VerifyMac0(CBORObject control, byte[] rgbData)
     throws CoseException {
     CBORObject cnInput = control.get("input");
-    int type;
-    boolean fFail = false;
     boolean fFailBody = false;
 
     try {
@@ -479,14 +457,14 @@ public class RegressionTest extends TestBase {
       recipient.SetKey(cnKey);
 
       CBORObject cnStatic = cnRecipients.get("sender_key");
-      if (cnStatic != null) {
-        if (recipient.findAttribute(HeaderKeys.ECDH_SPK) == null) {
-          recipient.addAttribute(
-            HeaderKeys.ECDH_SPK,
-            BuildKey(cnStatic, true).AsCBOR(),
-            Attribute.DO_NOT_SEND
-          );
-        }
+      if (
+        cnStatic != null && recipient.findAttribute(HeaderKeys.ECDH_SPK) == null
+      ) {
+        recipient.addAttribute(
+          HeaderKeys.ECDH_SPK,
+          BuildKey(cnStatic, true).AsCBOR(),
+          Attribute.DO_NOT_SEND
+        );
       }
 
       fFail = HasFailMarker(cnRecipients);
@@ -537,7 +515,6 @@ public class RegressionTest extends TestBase {
     Recipient hRecip1;
     Recipient hRecip2;
     boolean fRet = false;
-    int type;
     COSEKey cnkey;
     COSEObject msg;
 
@@ -568,14 +545,14 @@ public class RegressionTest extends TestBase {
         hRecip2.SetKey(cnkey);
 
         CBORObject cnStatic = cnRecipient2.get("sender_key");
-        if (cnStatic != null) {
-          if (hRecip2.findAttribute(HeaderKeys.ECDH_SPK) == null) {
-            hRecip2.addAttribute(
-              HeaderKeys.ECDH_SPK,
-              BuildKey(cnStatic, true).AsCBOR(),
-              Attribute.DO_NOT_SEND
-            );
-          }
+        if (
+          cnStatic != null && hRecip2.findAttribute(HeaderKeys.ECDH_SPK) == null
+        ) {
+          hRecip2.addAttribute(
+            HeaderKeys.ECDH_SPK,
+            BuildKey(cnStatic, true).AsCBOR(),
+            Attribute.DO_NOT_SEND
+          );
         }
 
         hRecip = hRecip2;
@@ -584,14 +561,14 @@ public class RegressionTest extends TestBase {
         hRecip1.SetKey(cnkey);
 
         CBORObject cnStatic = cnRecipient1.get("sender_key");
-        if (cnStatic != null) {
-          if (hRecip1.findAttribute(HeaderKeys.ECDH_SPK) == null) {
-            hRecip1.addAttribute(
-              HeaderKeys.ECDH_SPK,
-              BuildKey(cnStatic, true).AsCBOR(),
-              Attribute.DO_NOT_SEND
-            );
-          }
+        if (
+          cnStatic != null && hRecip1.findAttribute(HeaderKeys.ECDH_SPK) == null
+        ) {
+          hRecip1.addAttribute(
+            HeaderKeys.ECDH_SPK,
+            BuildKey(cnStatic, true).AsCBOR(),
+            Attribute.DO_NOT_SEND
+          );
         }
 
         hRecip = hRecip1;
@@ -603,7 +580,7 @@ public class RegressionTest extends TestBase {
       }
 
       try {
-        byte[] rgbOut = hEnc.decrypt(hRecip);
+        hEnc.decrypt(hRecip);
         if (fFailBody) fRet = false;
         else fRet = true;
       } catch (CoseException e) {
@@ -638,7 +615,6 @@ public class RegressionTest extends TestBase {
   int _ValidateEnveloped(CBORObject cnControl, byte[] rgbEncoded)
     throws CoseException {
     CBORObject cnInput = cnControl.get("input");
-    CBORObject cnFail;
     CBORObject cnEnveloped;
     CBORObject cnRecipients;
     int iRecipient;
@@ -778,15 +754,11 @@ public class RegressionTest extends TestBase {
 
     byte[] rgb = hEncObj.EncodeToBytes();
 
-    int f = _ValidateEnveloped(cnControl, rgb);
-
-    return;
+    _ValidateEnveloped(cnControl, rgb);
   }
 
   public void SetReceivingAttributes(Attribute msg, CBORObject cnIn)
     throws Exception {
-    boolean f = false;
-
     SetAttributes(msg, cnIn.get("unsent"), Attribute.DO_NOT_SEND, true);
 
     CBORObject cnExternal = cnIn.get("external");
@@ -1259,12 +1231,11 @@ public class RegressionTest extends TestBase {
   int _ValidateSigned(CBORObject cnControl, byte[] pbEncoded)
     throws CoseException {
     CBORObject cnInput = cnControl.get("input");
-    CBORObject pFail;
+
     CBORObject cnSign;
     CBORObject cnSigners;
     CBORObject cnCounter;
     SignCOSEObject hSig = null;
-    int type;
     int iSigner;
     boolean fFailBody;
 
@@ -1430,7 +1401,6 @@ public class RegressionTest extends TestBase {
     CBORObject cnInput = cnControl.get("input");
     CBORObject cnSign;
     Sign1COSEObject hSig;
-    int type;
     boolean fFail;
 
     try {
@@ -1531,7 +1501,7 @@ public class RegressionTest extends TestBase {
       return 0;
     }
 
-    int f = _ValidateSign0(cnControl, rgb);
+    _ValidateSign0(cnControl, rgb);
     return 0;
   }
 
@@ -1539,9 +1509,9 @@ public class RegressionTest extends TestBase {
     throws CoseException, Exception {
     if (cSigInfo.getType() == CBORType.Map) {
       if (
-        (!cSigInfo.ContainsKey("signers") ||
-          (cSigInfo.get("signers").getType() != CBORType.Array) ||
-          (cSigInfo.get("signers").getValues().size() != 1))
+        !cSigInfo.ContainsKey("signers") ||
+        cSigInfo.get("signers").getType() != CBORType.Array ||
+        cSigInfo.get("signers").getValues().size() != 1
       ) {
         throw new CoseException("Invalid input file");
       }
@@ -1565,9 +1535,9 @@ public class RegressionTest extends TestBase {
     throws CoseException, Exception {
     if (cSigInfo.getType() == CBORType.Map) {
       if (
-        (!cSigInfo.ContainsKey("signers") ||
-          (cSigInfo.get("signers").getType() != CBORType.Array) ||
-          (cSigInfo.get("signers").getValues().size() != 1))
+        !cSigInfo.ContainsKey("signers") ||
+        cSigInfo.get("signers").getType() != CBORType.Array ||
+        cSigInfo.get("signers").getValues().size() != 1
       ) {
         throw new CoseException("Invalid input file");
       }

--- a/src/test/java/se/digg/cose/RegressionTest.java
+++ b/src/test/java/se/digg/cose/RegressionTest.java
@@ -168,7 +168,7 @@ public class RegressionTest extends TestBase {
 
     COSEKey cnKey = BuildKey(cnRecipients.get("key"), true);
 
-    CBORObject kk = cnKey.get(CBORObject.FromObject(-1));
+    CBORObject kk = cnKey.get(CBORObject.FromInt32(-1));
 
     msg.encrypt(kk.GetByteString());
 
@@ -215,7 +215,7 @@ public class RegressionTest extends TestBase {
 
       COSEKey cnKey = BuildKey(cnRecipients.get("key"), true);
 
-      CBORObject kk = cnKey.get(CBORObject.FromObject(-1));
+      CBORObject kk = cnKey.get(CBORObject.FromInt32(-1));
 
       cnFail = cnRecipients.get("fail");
 
@@ -343,7 +343,7 @@ public class RegressionTest extends TestBase {
 
     COSEKey cnKey = BuildKey(cnRecipients.get("key"), true);
 
-    CBORObject kk = cnKey.get(CBORObject.FromObject(-1));
+    CBORObject kk = cnKey.get(CBORObject.FromInt32(-1));
 
     msg.Create(kk.GetByteString());
 
@@ -384,7 +384,7 @@ public class RegressionTest extends TestBase {
 
       COSEKey cnKey = BuildKey(cnRecipients.get("key"), true);
 
-      CBORObject kk = cnKey.get(CBORObject.FromObject(-1));
+      CBORObject kk = cnKey.get(CBORObject.FromInt32(-1));
 
       pFail = cnRecipients.get("fail");
 
@@ -803,80 +803,80 @@ public class RegressionTest extends TestBase {
           break;
         case "kid":
           cnKey = HeaderKeys.KID.AsCBOR();
-          cnValue = CBORObject.FromObject(
+          cnValue = CBORObject.FromByteArray(
             cnAttributes.get(attr).AsString().getBytes()
           );
           break;
         case "spk_kid":
           cnKey = HeaderKeys.ECDH_SKID.AsCBOR();
-          cnValue = CBORObject.FromObject(
+          cnValue = CBORObject.FromByteArray(
             cnAttributes.get(attr).AsString().getBytes()
           );
           break;
         case "IV_hex":
           cnKey = HeaderKeys.IV.AsCBOR();
-          cnValue = CBORObject.FromObject(
+          cnValue = CBORObject.FromByteArray(
             hexStringToByteArray(cnAttributes.get(attr).AsString())
           );
           break;
         case "partialIV_hex":
           cnKey = HeaderKeys.PARTIAL_IV.AsCBOR();
-          cnValue = CBORObject.FromObject(
+          cnValue = CBORObject.FromByteArray(
             hexStringToByteArray(cnAttributes.get(attr).AsString())
           );
           break;
         case "salt":
           cnKey = HeaderKeys.HKDF_Salt.AsCBOR();
-          cnValue = CBORObject.FromObject(
+          cnValue = CBORObject.FromByteArray(
             cnAttributes.get(attr).AsString().getBytes()
           );
           break;
         case "apu_id":
           cnKey = HeaderKeys.HKDF_Context_PartyU_ID.AsCBOR();
-          cnValue = CBORObject.FromObject(
+          cnValue = CBORObject.FromByteArray(
             cnAttributes.get(attr).AsString().getBytes()
           );
           break;
         case "apv_id":
           cnKey = HeaderKeys.HKDF_Context_PartyV_ID.AsCBOR();
-          cnValue = CBORObject.FromObject(
+          cnValue = CBORObject.FromByteArray(
             cnAttributes.get(attr).AsString().getBytes()
           );
           break;
         case "apu_nonce":
         case "apu_nonce_hex":
           cnKey = HeaderKeys.HKDF_Context_PartyU_nonce.AsCBOR();
-          cnValue = CBORObject.FromObject(
+          cnValue = CBORObject.FromByteArray(
             cnAttributes.get(attr).AsString().getBytes()
           );
           break;
         case "apv_nonce":
           cnKey = HeaderKeys.HKDF_Context_PartyV_nonce.AsCBOR();
-          cnValue = CBORObject.FromObject(
+          cnValue = CBORObject.FromByteArray(
             cnAttributes.get(attr).AsString().getBytes()
           );
           break;
         case "apu_other":
           cnKey = HeaderKeys.HKDF_Context_PartyU_Other.AsCBOR();
-          cnValue = CBORObject.FromObject(
+          cnValue = CBORObject.FromByteArray(
             cnAttributes.get(attr).AsString().getBytes()
           );
           break;
         case "apv_other":
           cnKey = HeaderKeys.HKDF_Context_PartyV_Other.AsCBOR();
-          cnValue = CBORObject.FromObject(
+          cnValue = CBORObject.FromByteArray(
             cnAttributes.get(attr).AsString().getBytes()
           );
           break;
         case "pub_other":
           cnKey = HeaderKeys.HKDF_SuppPub_Other.AsCBOR();
-          cnValue = CBORObject.FromObject(
+          cnValue = CBORObject.FromByteArray(
             cnAttributes.get(attr).AsString().getBytes()
           );
           break;
         case "priv_other":
           cnKey = HeaderKeys.HKDF_SuppPriv_Other.AsCBOR();
-          cnValue = CBORObject.FromObject(
+          cnValue = CBORObject.FromByteArray(
             cnAttributes.get(attr).AsString().getBytes()
           );
           break;
@@ -923,29 +923,29 @@ public class RegressionTest extends TestBase {
         case "kty":
           switch (cnValue.AsString()) {
             case "EC":
-              cnKeyOut.set(CBORObject.FromObject(1), CBORObject.FromObject(2));
+              cnKeyOut.set(CBORObject.FromInt32(1), CBORObject.FromInt32(2));
               break;
             case "OKP":
-              cnKeyOut.set(CBORObject.FromObject(1), KeyKeys.KeyType_OKP);
+              cnKeyOut.set(CBORObject.FromInt32(1), KeyKeys.KeyType_OKP);
               break;
             case "oct":
-              cnKeyOut.set(CBORObject.FromObject(1), CBORObject.FromObject(4));
+              cnKeyOut.set(CBORObject.FromInt32(1), CBORObject.FromInt32(4));
               break;
             case "RSA":
-              cnKeyOut.set(CBORObject.FromObject(1), KeyKeys.KeyType_RSA);
+              cnKeyOut.set(CBORObject.FromInt32(1), KeyKeys.KeyType_RSA);
               break;
           }
           break;
         case "crv":
           switch (cnValue.AsString()) {
             case "P-256":
-              cnValue = CBORObject.FromObject(1);
+              cnValue = CBORObject.FromInt32(1);
               break;
             case "P-384":
-              cnValue = CBORObject.FromObject(2);
+              cnValue = CBORObject.FromInt32(2);
               break;
             case "P-521":
-              cnValue = CBORObject.FromObject(3);
+              cnValue = CBORObject.FromInt32(3);
               break;
             case "Ed25519":
               cnValue = KeyKeys.OKP_Ed25519;
@@ -963,12 +963,12 @@ public class RegressionTest extends TestBase {
               break;
           }
 
-          cnKeyOut.set(CBORObject.FromObject(-1), cnValue);
+          cnKeyOut.set(CBORObject.FromInt32(-1), cnValue);
           break;
         case "x":
           cnKeyOut.set(
             KeyKeys.EC2_X.AsCBOR(),
-            CBORObject.FromObject(
+            CBORObject.FromByteArray(
               Base64.getUrlDecoder().decode(cnValue.AsString())
             )
           );
@@ -976,13 +976,13 @@ public class RegressionTest extends TestBase {
         case "x_hex":
           cnKeyOut.set(
             KeyKeys.EC2_X.AsCBOR(),
-            CBORObject.FromObject(hexStringToByteArray(cnValue.AsString()))
+            CBORObject.FromByteArray(hexStringToByteArray(cnValue.AsString()))
           );
           break;
         case "y":
           cnKeyOut.set(
             KeyKeys.EC2_Y.AsCBOR(),
-            CBORObject.FromObject(
+            CBORObject.FromByteArray(
               Base64.getUrlDecoder().decode(cnValue.AsString())
             )
           );
@@ -990,14 +990,14 @@ public class RegressionTest extends TestBase {
         case "y_hex":
           cnKeyOut.set(
             KeyKeys.EC2_Y.AsCBOR(),
-            CBORObject.FromObject(hexStringToByteArray(cnValue.AsString()))
+            CBORObject.FromByteArray(hexStringToByteArray(cnValue.AsString()))
           );
           break;
         case "d":
           if (!fPublicKey) {
             cnKeyOut.set(
               KeyKeys.EC2_D.AsCBOR(),
-              CBORObject.FromObject(
+              CBORObject.FromByteArray(
                 Base64.getUrlDecoder().decode(cnValue.AsString())
               )
             );
@@ -1007,35 +1007,35 @@ public class RegressionTest extends TestBase {
           if (keyIn.get("kty").AsString().equals("RSA")) {
             cnKeyOut.set(
               KeyKeys.RSA_D.AsCBOR(),
-              CBORObject.FromObject(hexStringToByteArray(cnValue.AsString()))
+              CBORObject.FromByteArray(hexStringToByteArray(cnValue.AsString()))
             );
             break;
           }
           if (!fPublicKey) {
             cnKeyOut.set(
               KeyKeys.EC2_D.AsCBOR(),
-              CBORObject.FromObject(hexStringToByteArray(cnValue.AsString()))
+              CBORObject.FromByteArray(hexStringToByteArray(cnValue.AsString()))
             );
           }
           break;
         case "k":
           cnKeyOut.set(
-            CBORObject.FromObject(-1),
-            CBORObject.FromObject(
+            CBORObject.FromInt32(-1),
+            CBORObject.FromByteArray(
               Base64.getUrlDecoder().decode(cnValue.AsString())
             )
           );
           break;
         case "k_hex":
           cnKeyOut.set(
-            CBORObject.FromObject(-1),
-            CBORObject.FromObject(hexStringToByteArray(cnValue.AsString()))
+            CBORObject.FromInt32(-1),
+            CBORObject.FromByteArray(hexStringToByteArray(cnValue.AsString()))
           );
           break;
         case "kid":
           cnKeyOut.set(
             CBORObject.FromObject(KeyKeys.KeyId),
-            CBORObject.FromObject(
+            CBORObject.FromByteArray(
               StandardCharsets.UTF_8.encode(cnValue.AsString()).array()
             )
           );
@@ -1043,49 +1043,49 @@ public class RegressionTest extends TestBase {
         case "kid_hex":
           cnKeyOut.set(
             CBORObject.FromObject(KeyKeys.KeyId),
-            CBORObject.FromObject(hexStringToByteArray(cnValue.AsString()))
+            CBORObject.FromByteArray(hexStringToByteArray(cnValue.AsString()))
           );
           break;
         case "n_hex":
           cnKeyOut.set(
             KeyKeys.RSA_N.AsCBOR(),
-            CBORObject.FromObject(hexStringToByteArray(cnValue.AsString()))
+            CBORObject.FromByteArray(hexStringToByteArray(cnValue.AsString()))
           );
           break;
         case "e_hex":
           cnKeyOut.set(
             KeyKeys.RSA_E.AsCBOR(),
-            CBORObject.FromObject(hexStringToByteArray(cnValue.AsString()))
+            CBORObject.FromByteArray(hexStringToByteArray(cnValue.AsString()))
           );
           break;
         case "p_hex":
           cnKeyOut.set(
             KeyKeys.RSA_P.AsCBOR(),
-            CBORObject.FromObject(hexStringToByteArray(cnValue.AsString()))
+            CBORObject.FromByteArray(hexStringToByteArray(cnValue.AsString()))
           );
           break;
         case "q_hex":
           cnKeyOut.set(
             KeyKeys.RSA_Q.AsCBOR(),
-            CBORObject.FromObject(hexStringToByteArray(cnValue.AsString()))
+            CBORObject.FromByteArray(hexStringToByteArray(cnValue.AsString()))
           );
           break;
         case "dP_hex":
           cnKeyOut.set(
             KeyKeys.RSA_DP.AsCBOR(),
-            CBORObject.FromObject(hexStringToByteArray(cnValue.AsString()))
+            CBORObject.FromByteArray(hexStringToByteArray(cnValue.AsString()))
           );
           break;
         case "dQ_hex":
           cnKeyOut.set(
             KeyKeys.RSA_DQ.AsCBOR(),
-            CBORObject.FromObject(hexStringToByteArray(cnValue.AsString()))
+            CBORObject.FromByteArray(hexStringToByteArray(cnValue.AsString()))
           );
           break;
         case "qi_hex":
           cnKeyOut.set(
             KeyKeys.RSA_QI.AsCBOR(),
-            CBORObject.FromObject(hexStringToByteArray(cnValue.AsString()))
+            CBORObject.FromByteArray(hexStringToByteArray(cnValue.AsString()))
           );
           break;
       }

--- a/src/test/java/se/digg/cose/Sign1COSEObjectTest.java
+++ b/src/test/java/se/digg/cose/Sign1COSEObjectTest.java
@@ -186,7 +186,7 @@ public class Sign1COSEObjectTest extends TestBase {
     thrown.expectMessage("Unknown Algorithm Specified");
     msg.addAttribute(
       HeaderKeys.Algorithm,
-      CBORObject.FromObject("Unknown"),
+      CBORObject.FromString("Unknown"),
       Attribute.PROTECTED
     );
     msg.SetContent(rgbContent);
@@ -293,7 +293,7 @@ public class Sign1COSEObjectTest extends TestBase {
   @Test
   public void decodeBadProtected2() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.False.EncodeToBytes()));
+    obj.Add(CBORObject.FromByteArray(CBORObject.False.EncodeToBytes()));
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
@@ -308,7 +308,7 @@ public class Sign1COSEObjectTest extends TestBase {
   @Test
   public void decodeBadUnprotected() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
@@ -323,7 +323,7 @@ public class Sign1COSEObjectTest extends TestBase {
   @Test
   public void decodeBadContent() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.NewMap());
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
@@ -338,7 +338,7 @@ public class Sign1COSEObjectTest extends TestBase {
   @Test
   public void decodeBadSignature() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.NewMap());
     obj.Add(new byte[0]);
     obj.Add(CBORObject.False);

--- a/src/test/java/se/digg/cose/Sign1COSEObjectTest.java
+++ b/src/test/java/se/digg/cose/Sign1COSEObjectTest.java
@@ -21,15 +21,6 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import se.digg.cose.AlgorithmID;
-import se.digg.cose.Attribute;
-import se.digg.cose.COSEKey;
-import se.digg.cose.COSEObject;
-import se.digg.cose.COSEObjectTag;
-import se.digg.cose.CoseException;
-import se.digg.cose.HeaderKeys;
-import se.digg.cose.KeyKeys;
-import se.digg.cose.Sign1COSEObject;
 
 /**
  *
@@ -92,7 +83,6 @@ public class Sign1COSEObjectTest extends TestBase {
 
     byte[] rgbX = keyPublic.getQ().normalize().getXCoord().getEncoded();
     byte[] rgbY = keyPublic.getQ().normalize().getYCoord().getEncoded();
-    boolean signY = true;
     byte[] rgbD = keyPrivate.getD().toByteArray();
 
     CBORObject key = CBORObject.NewMap();
@@ -150,7 +140,7 @@ public class Sign1COSEObjectTest extends TestBase {
     );
     boolean f = msg.validate(cnKeyPublic);
 
-    assert (f);
+    assert f;
   }
 
   /**
@@ -175,7 +165,7 @@ public class Sign1COSEObjectTest extends TestBase {
     );
     boolean f = msg.validate(cnKeyPublic);
 
-    assert (f);
+    assert f;
   }
 
   @Test
@@ -270,7 +260,7 @@ public class Sign1COSEObjectTest extends TestBase {
     thrown.expectMessage("COSEObject is not a COSE security COSEObject");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign1);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign1);
   }
 
   @Test
@@ -282,7 +272,7 @@ public class Sign1COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Sign1 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign1);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign1);
   }
 
   @Test
@@ -297,7 +287,7 @@ public class Sign1COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Sign1 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign1);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign1);
   }
 
   @Test
@@ -312,7 +302,7 @@ public class Sign1COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Sign1 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign1);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign1);
   }
 
   @Test
@@ -327,7 +317,7 @@ public class Sign1COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Sign1 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign1);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign1);
   }
 
   @Test
@@ -342,7 +332,7 @@ public class Sign1COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Sign1 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign1);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign1);
   }
 
   @Test
@@ -357,6 +347,6 @@ public class Sign1COSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid Sign1 structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign1);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign1);
   }
 }

--- a/src/test/java/se/digg/cose/Sign1WikiTest.java
+++ b/src/test/java/se/digg/cose/Sign1WikiTest.java
@@ -9,14 +9,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import se.digg.cose.AlgorithmID;
-import se.digg.cose.Attribute;
-import se.digg.cose.COSEKey;
-import se.digg.cose.COSEObject;
-import se.digg.cose.CoseException;
-import se.digg.cose.HeaderKeys;
-import se.digg.cose.KeyKeys;
-import se.digg.cose.Sign1COSEObject;
 
 /**
  *
@@ -41,15 +33,15 @@ public class Sign1WikiTest extends TestBase {
   @Test
   public void testSignAMessage() throws CoseException {
     byte[] result = SignAMessage("This is lots of content");
-    assert (VerifyAMessage(result, signingKey));
-    assert (!VerifyAMessage(result, sign2Key));
+    assert VerifyAMessage(result, signingKey);
+    assert !VerifyAMessage(result, sign2Key);
   }
 
   public static byte[] SignAMessage(String ContentToSign) throws CoseException {
-    //  Create the signed message
+    // Create the signed message
     Sign1COSEObject msg = new Sign1COSEObject();
 
-    //  Add the content to the message
+    // Add the content to the message
     msg.SetContent(ContentToSign);
     msg.addAttribute(
       HeaderKeys.Algorithm,
@@ -57,10 +49,10 @@ public class Sign1WikiTest extends TestBase {
       Attribute.PROTECTED
     );
 
-    //  Force the message to be signed
+    // Force the message to be signed
     msg.sign(signingKey);
 
-    //  Now serialize out the message
+    // Now serialize out the message
     return msg.EncodeToBytes();
   }
 

--- a/src/test/java/se/digg/cose/SignCOSEObjectTest.java
+++ b/src/test/java/se/digg/cose/SignCOSEObjectTest.java
@@ -5,21 +5,18 @@
 
 package se.digg.cose;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import com.upokecenter.cbor.CBORObject;
-import org.junit.*;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import se.digg.cose.COSEObject;
-import se.digg.cose.COSEObjectTag;
-import se.digg.cose.CoseException;
-import se.digg.cose.SignCOSEObject;
-import se.digg.cose.Signer;
 
 /**
  *
@@ -123,7 +120,7 @@ public class SignCOSEObjectTest extends TestBase {
     thrown.expectMessage("COSEObject is not a COSE security COSEObject");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign);
   }
 
   @Test
@@ -135,7 +132,7 @@ public class SignCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid SignCOSEObject structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign);
   }
 
   @Test
@@ -150,7 +147,7 @@ public class SignCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid SignCOSEObject structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign);
   }
 
   @Test
@@ -165,7 +162,7 @@ public class SignCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid SignCOSEObject structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign);
   }
 
   @Test
@@ -180,7 +177,7 @@ public class SignCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid SignCOSEObject structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign);
   }
 
   @Test
@@ -195,7 +192,7 @@ public class SignCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid SignCOSEObject structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign);
   }
 
   @Test
@@ -210,6 +207,6 @@ public class SignCOSEObjectTest extends TestBase {
     thrown.expectMessage("Invalid SignCOSEObject structure");
 
     byte[] rgb = obj.EncodeToBytes();
-    COSEObject msg = COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign);
+    COSEObject.DecodeFromBytes(rgb, COSEObjectTag.Sign);
   }
 }

--- a/src/test/java/se/digg/cose/SignCOSEObjectTest.java
+++ b/src/test/java/se/digg/cose/SignCOSEObjectTest.java
@@ -153,7 +153,7 @@ public class SignCOSEObjectTest extends TestBase {
   @Test
   public void signDecodeBadProtected2() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.False));
+    obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
@@ -168,7 +168,7 @@ public class SignCOSEObjectTest extends TestBase {
   @Test
   public void signDecodeBadUnprotected() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
@@ -183,7 +183,7 @@ public class SignCOSEObjectTest extends TestBase {
   @Test
   public void signDecodeBadContent() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.NewMap());
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
@@ -198,7 +198,7 @@ public class SignCOSEObjectTest extends TestBase {
   @Test
   public void signDecodeBadRecipients() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.NewMap());
     obj.Add(new byte[0]);
     obj.Add(CBORObject.False);

--- a/src/test/java/se/digg/cose/SignerTest.java
+++ b/src/test/java/se/digg/cose/SignerTest.java
@@ -94,7 +94,7 @@ public class SignerTest extends TestBase {
   @Test
   public void signerDecodeBadProtected2() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.False));
+    obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
 
@@ -108,7 +108,7 @@ public class SignerTest extends TestBase {
   @Test
   public void signerDecodeBadUnprotected() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.False);
     obj.Add(CBORObject.False);
 
@@ -122,7 +122,7 @@ public class SignerTest extends TestBase {
   @Test
   public void signerDecodeBadSignature() throws CoseException {
     CBORObject obj = CBORObject.NewArray();
-    obj.Add(CBORObject.FromObject(CBORObject.NewArray()).EncodeToBytes());
+    obj.Add(CBORObject.NewArray()).EncodeToBytes();
     obj.Add(CBORObject.NewMap());
     obj.Add(CBORObject.False);
 

--- a/src/test/java/se/digg/cose/SignerTest.java
+++ b/src/test/java/se/digg/cose/SignerTest.java
@@ -5,20 +5,17 @@
 
 package se.digg.cose;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
 
 import com.upokecenter.cbor.CBORObject;
-import org.junit.*;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import se.digg.cose.COSEKey;
-import se.digg.cose.CoseException;
-import se.digg.cose.Signer;
 
 /**
  *


### PR DESCRIPTION
Fix remaning linter warnings
Fix outdated fromobject methods.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
