### PR TITLE
chore: add central publishing with jreleaser

### DIFF
--- a/.github/workflows/release-lib.yml
+++ b/.github/workflows/release-lib.yml
@@ -34,11 +34,60 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
      
+      - name: Set JReleaser environment variables based on tag
+        id: set-jreleaser-env
+        run: |
+            # shellcheck disable=SC2086 
+            echo "Starting JReleaser environment configuration..."
+
+            # Default to SNAPSHOT logic for safety
+            release_active="NEVER"
+            snapshot_active="SNAPSHOT"
+            echo "Default configuration set to SNAPSHOT mode for safety"
+
+            # Create a temp directory in the workspace
+            mkdir -p .tmp
+
+            # Get the latest tag
+            git describe --tags --abbrev=0 > .tmp/latest_tag 2>/dev/null
+
+            # shellcheck disable=SC2181
+            if [ $? -eq 0 ]; then
+              LATEST_TAG=$(cat .tmp/latest_tag)
+              echo "Latest tag detected: $LATEST_TAG"
+              
+              # Check if the tag exists and does NOT have a -SNAPSHOT suffix
+              if [[ -n "$LATEST_TAG" && "$LATEST_TAG" != *"-SNAPSHOT" ]]; then
+                # Only change to release configuration if we have a confirmed non-SNAPSHOT tag
+                echo "[SUCCESS] Valid release tag detected. Setting up for RELEASE configuration."
+                release_active="ALWAYS"
+                snapshot_active="NEVER"
+              else
+                if [[ "$LATEST_TAG" == *"-SNAPSHOT" ]]; then
+                  echo "[INFO] SNAPSHOT tag detected. Using SNAPSHOT configuration."
+                else
+                  echo "[WARNING] Tag format unclear. Defaulting to SNAPSHOT configuration for safety."
+                fi
+              fi
+            else
+              echo "[WARNING] Failed to get latest tag. Defaulting to SNAPSHOT configuration for safety."
+            fi        
+
+            # Set the outputs
+            echo "release_active=${release_active}" >> "$GITHUB_OUTPUT"
+            echo "snapshot_active=${snapshot_active}" >> "$GITHUB_OUTPUT"
+            
+      - name: Fetch git-cliff templates
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: diggsweden/.github
+          path: .github-templates
+          ref: main
           
       - name: Generate Releasenotes
         uses: orhun/git-cliff-action@4a4a951bc43fafe41cd2348d181853f52356bee7 # v4.4.2
         with:
-          args: --latest
+          args: --latest --config .github-templates/gitcliff-templates/default.toml
         env:
           OUTPUT: ReleasenotesTmp
           GITHUB_REPO: ${{ github.repository }}
@@ -52,10 +101,12 @@ jobs:
           JRELEASER_GPG_PUBLIC_KEY: ${{ secrets.OSPO_BOT_GPG_PUB }}
           JRELEASER_GPG_SECRET_KEY: ${{ secrets.OSPO_BOT_GPG_PRIV }}
           JRELEASER_GPG_PASSPHRASE: ${{ secrets.OSPO_BOT_GPG_PASS }}
+          JRELEASER_DEPLOY_MAVEN_MAVENCENTRAL_RELEASE_ACTIVE: ${{ steps.set-jreleaser-env.outputs.release_active }}
+          JRELEASER_DEPLOY_MAVEN_MAVENCENTRAL_SNAPSHOT_ACTIVE: ${{ steps.set-jreleaser-env.outputs.snapshot_active }}
         run: |
           # shellcheck disable=SC2086 
           mvn $MAVEN_CLI_OPTS deploy jreleaser:full-release -DskipTests
-
+      
       - name: JReleaser output
         if: always()
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.1
@@ -63,5 +114,4 @@ jobs:
           name: jreleaser-logs
           path: |
             target/jreleaser/trace.log
-            target/jreleaser/output.properties
-            
+            target/jreleaser/output.properties           

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -3,7 +3,7 @@ project:
   name: cose-lib
   description: A Java implementation that supports the COSE secure message specification.</description>
   license: BSD-3-Clause 
-  copyright: 2025 Digg - Agency for Digital Government
+  copyright: 2025 diggsweden/cose-lib
   inceptionYear: 2025
   snapshot:
     pattern: .*-SNAPSHOT
@@ -31,24 +31,30 @@ signing:
   active: ALWAYS
   armored: true
 
-# Maven deployment to GitHub packages
+# Maven deployment
 deploy:
+  enabled: true
   maven:
-    github:
-      app:
-        active: ALWAYS
-        url: https://maven.pkg.github.com/diggsweden/cose-lib
-        applyMavenCentralRules: true
-        snapshotSupported: true
-        stagingRepositories:           
-          - target/staging-deploy
+    # github:
+    #   app:
+    #     active: ALWAYS
+    #     url: https://maven.pkg.github.com/diggsweden/cose-lib
+    #     applyMavenCentralRules: true
+    #     snapshotSupported: true
+    #     stagingRepositories:           
+    #       - target/staging-deploy
     mavenCentral:
-      app:
-        active: ALWAYS
-        url: https://central.sonatype.com/repository/maven-snapshots/
+      snapshot:
+        url: https://central.sonatype.com
+        verifyUrl: https://central.sonatype.com/repository/maven-snapshots/
         applyMavenCentralRules: true
         stagingRepositories:
-          - target/staging-deploy
+          - target/central-deferred
+      release:
+        url: https://central.sonatype.com
+        applyMavenCentralRules: true
+        stagingRepositories:
+          - target/central-staging
 
 # SBOM generation
 catalog:

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <maven.gpg.plugin.version>3.1.0</maven.gpg.plugin.version>
     <maven.enforcer.plugin.version>3.5.0</maven.enforcer.plugin.version>
     <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
-    <jreleaser-maven-plugin.version>1.16.0</jreleaser-maven-plugin.version>
+    <jreleaser-maven-plugin.version>1.17.0</jreleaser-maven-plugin.version>
     <formatter-maven-plugin.version>2.25.0</formatter-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.6.0</maven-checkstyle-plugin.version>
     <checkstyle.version>10.21.2</checkstyle.version>
@@ -241,12 +241,14 @@
 
       <!-- Deployment -->
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-deploy-plugin</artifactId>
-        <version>${maven-deploy-plugin.version}</version>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <version>0.7.0</version>
+        <extensions>true</extensions>
         <configuration>
-          <altDeploymentRepository>local::file:./target/staging-deploy</altDeploymentRepository>
-          <skip>false</skip>
+          <checksums>all</checksums>
+          <skipPublishing>true</skipPublishing>
+          <publishingServerId>central</publishingServerId>
         </configuration>
       </plugin>
 


### PR DESCRIPTION
Add test config for mvn central portal api publishing and logic for ci.
Untested in new jreleaser so this will be interesting... and needs some testing and verification
Also uses the git-cliff release template from diggswedens github, as it filters chore(release): commits by default.

## Checklist

- [x] Changes are limited to a single goal (avoid scope creep)
- [x] I confirm that I have read any Contribution and Development guidelines (CONTRIBUTING and DEVELOPMENT) and are following their suggestions.
- [x] I confirm that I wrote and/or have the right to submit the contents of my Pull Request, by agreeing to the _Developer Certificate of Origin_, (adding a 'sign-off' to my commits).
